### PR TITLE
Add the collaboration guidelines and community content.

### DIFF
--- a/source/clear-linux/reference/collaboration/collaboration.rst
+++ b/source/clear-linux/reference/collaboration/collaboration.rst
@@ -1,0 +1,17 @@
+.. _collaboration:
+
+Collaboration guidelines
+########################
+
+Thank you for your interest in collaborating with the |CLOSIA|. This guide
+details the best ways to communicate and collaborate with the |CL| team. The
+documentation section provides all the information you need to help us
+improve our documents with your use case tutorials, examples, or task focused
+guides. Read the information carefully before submitting any work for review
+to ensure your contribution can be added as quickly as possible.
+
+.. toctree::
+   :maxdepth: 1
+
+   community/community
+

--- a/source/clear-linux/reference/collaboration/community/bug-report.rst
+++ b/source/clear-linux/reference/collaboration/community/bug-report.rst
@@ -1,0 +1,33 @@
+.. _bug-report:
+
+Bug report template
+###################
+
+Use this simple template to provide us all the information needed to address
+the issue as quickly as possible. Submit your bugs to the |CLOSIA|
+`mailing list`_ at: dev@lists.clearlinux.org.
+
+**Title:** Be descriptive and brief, 78 characters in length.
+
+**Severity:** Classify the bug as: minor, major, or critical. Minor bugs have
+no real impact on the functionality and are cosmetic or design errors, such
+as a text block exceeding its boundaries, an image out of alignment, or a
+typo. Major bugs prevent the application from meeting requirements or carrying
+out a feature. Major bugs prevent |CL| from completing an intended task or
+functionality as intended. Critical bugs prevent you from using |CL| any
+further. Critical bugs include crashes, broken interfaces, and any other
+so-called showstoppers.
+
+**System:** Provide the information of the system that ran into the issue.
+For documentation bugs, provide the URL of the page where you
+encountered the problem.
+
+**Description:** Provide the steps needed to replicate the issue. Specify any
+input accurately and in the correct order. In the case of documentation,
+specify the paragraph with the problem and, if applicable, suggestions on how
+to fix it.
+
+**GitHub username:** Provide your GitHub username for any possible follow up
+on the pull requests addressing the issue.
+
+.. _mailing list: https://lists.clearlinux.org/mailman/listinfo/dev

--- a/source/clear-linux/reference/collaboration/community/bug-report.rst
+++ b/source/clear-linux/reference/collaboration/community/bug-report.rst
@@ -22,10 +22,12 @@ so-called showstoppers.
 For documentation bugs, provide the URL of the page where you
 encountered the problem.
 
-**Description:** Provide the steps needed to replicate the issue. Specify any
-input accurately and in the correct order. In the case of documentation,
-specify the paragraph with the problem and, if applicable, suggestions on how
-to fix it.
+**Description:** Provide a description of the problem and how the actual
+behaviour differs from the expected behavior. Also provide the version of
+|CL| exhibiting the behavior. Lastly, provide the detailed steps to replicate
+the issue. Specify any input accurately and in the correct order. In the case
+of documentation, specify the paragraph with the problem and, if applicable,
+suggestions on how to fix it.
 
 **GitHub username:** Provide your GitHub username for any possible follow up
 on the pull requests addressing the issue.

--- a/source/clear-linux/reference/collaboration/community/bug-report.rst
+++ b/source/clear-linux/reference/collaboration/community/bug-report.rst
@@ -3,9 +3,10 @@
 Bug report template
 ###################
 
-Use this simple template to provide us all the information needed to address
-the issue as quickly as possible. Submit your bugs to the |CLOSIA|
-`mailing list`_ at: dev@lists.clearlinux.org.
+This simple template helps you provide all the information needed to address
+an issue. Use the template to ensure the issue is resolved as quickly as
+possible. Submit your bugs to the |CLOSIA| `mailing list`_ at:
+dev@lists.clearlinux.org.
 
 **Title:** Be descriptive and brief, 78 characters in length.
 

--- a/source/clear-linux/reference/collaboration/community/community.rst
+++ b/source/clear-linux/reference/collaboration/community/community.rst
@@ -1,7 +1,7 @@
 .. _community:
 
-Community tools
-###############
+Welcome to the Clear Linux community
+####################################
 
 Open source is about sharing as much information as possible about your
 development. Maintainers and contributors must communicate effectively with
@@ -9,12 +9,10 @@ each other to build a development community. |CLOSIA| uses typical open
 source collaboration tools: a mailing list, an IRC channel, and GitHub. We
 strive to be open about our work with the entire community.
 
-In this spirit, do not send private feedback through email. Instead,
-send feedback to the mailing list by hitting 'Reply-to-all'
-and by keeping the CC list intact.
-
-The following sections contain information about the communication tools
-the |CL| project uses.
+These tools provide you with different options to engage and participate with
+the community. As with any tool, the community tools each serve a specific
+purpose. The following sections explain the ideal use of the tools. However,
+feel free to engage using the tool you feel most comfortable with.
 
 .. toctree::
    :maxdepth: 2

--- a/source/clear-linux/reference/collaboration/community/community.rst
+++ b/source/clear-linux/reference/collaboration/community/community.rst
@@ -1,0 +1,25 @@
+.. _community:
+
+Community tools
+###############
+
+Open source is about sharing as much information as possible about your
+development. Maintainers and contributors must communicate effectively with
+each other to build a development community. |CLOSIA| uses typical open
+source collaboration tools: a mailing list, an IRC channel, and GitHub. We
+strive to be open about our work with the entire community.
+
+In this spirit, do not send private feedback through email. Instead,
+send feedback to the mailing list by hitting 'Reply-to-all'
+and by keeping the CC list intact.
+
+The following sections contain information about the communication tools
+the |CL| project uses.
+
+.. toctree::
+   :maxdepth: 2
+
+   conduct
+   mailing
+   irc
+   bug-report

--- a/source/clear-linux/reference/collaboration/community/conduct.rst
+++ b/source/clear-linux/reference/collaboration/community/conduct.rst
@@ -7,17 +7,16 @@ The |CLOSIA| community is made up of a mixture of professionals and
 volunteers from all over the world. We strongly believe diversity is our
 strength and want to promote an inclusive and safe environment.
 
-To that end, we have a few ground rules for engaging in the community. The
-following code of conduct applies equally to all community participants,
-including project team leads, core contributors, mentors, users,
-participants, and those seeking help and guidance.
+To that end, the community follows a a few ground rules. The following code
+of conduct applies equally to all community participants: project team leads,
+core contributors, mentors, users, participants, and those seeking help and
+guidance.
 
-This code of conduct also applies to all spaces the project manages or
-authorizes, including IRC channels, the mailing lists, issue trackers,
-sponsored events, and any other forums the community uses and the project
-manages. In addition, violations of this code of conduct outside of these
-venues may affect a person's ability to participate within them after
-appropriate investigation.
+This code of conduct applies to all spaces the project manages or authorizes,
+including IRC channels, the mailing lists, issue trackers, sponsored events,
+and any other forums the community uses and the project manages. In addition,
+violations of this code of conduct outside of these venues may affect a
+person's ability to participate within them after appropriate investigation.
 
 **Be friendly, patient, and welcoming.** We strive to be a community that
 welcomes and supports people of all backgrounds and identities. This
@@ -36,7 +35,7 @@ contributions to the |CL| project will impact the work of others.
 
 **Be respectful.** Not all of us will agree all the time but disagreement is
 no excuse for poor behavior and poor manners. We might all experience some
-frustration now and then but we cannot allow frustration to turn into a
+frustration occasionally but we cannot allow frustration to turn into a
 personal attack. Remember, a community where people feel uncomfortable or
 threatened is not productive. Members of the |CL| community should be
 respectful when dealing with other contributors, people outside of the
@@ -88,6 +87,10 @@ acceptable and should be reported. This includes but is not limited to:
 * Advocating for, or encouraging, any of the above behavior.
 * Repeated harassment of others. In general, if someone asks you to stop,
   then stop.
+
+Violations to any of the points above will lead to a thorough investigation
+and review by the project leadership, who will determine the appropriate
+sanction.
 
 .. note::
    Portions of the |CL| code of conduct are derived from the code of conduct

--- a/source/clear-linux/reference/collaboration/community/conduct.rst
+++ b/source/clear-linux/reference/collaboration/community/conduct.rst
@@ -19,7 +19,7 @@ manages. In addition, violations of this code of conduct outside of these
 venues may affect a person's ability to participate within them after
 appropriate investigation.
 
-**Be friendly, patient and welcoming.** We strive to be a community that
+**Be friendly, patient, and welcoming.** We strive to be a community that
 welcomes and supports people of all backgrounds and identities. This
 includes, but is not limited to, members of any race, ethnicity, culture,
 national origin, color, immigration status, social and economic class,
@@ -66,7 +66,7 @@ viewpoint does not mean they are wrong. Focus on helping resolve issues and
 learning from mistakes. Resolve disagreements and differing views
 constructively and with the help of the community and community processes.
 
-**When we are unsure, we ask for help.** Nobody knows everything and nobody
+**When unsure, ask for help.** Nobody knows everything and nobody
 is expected to be perfect in the |CL| community. Asking questions avoids many
 problems down the road. So, questions are encouraged. If you are asked
 questions, be responsive and helpful. However, when asking a question, take
@@ -82,7 +82,7 @@ acceptable and should be reported. This includes but is not limited to:
 * Discriminatory jokes and language.
 * Posting sexually suggestive, explicit, or violent material.
 * Posting, or threatening to post, other people's personally identifying
-  information, AKA "doxing".
+  information, AKA "`doxing`_".
 * Personal insults, especially those using racist or sexist terms.
 * Unwelcome sexual attention.
 * Advocating for, or encouraging, any of the above behavior.
@@ -96,3 +96,5 @@ acceptable and should be reported. This includes but is not limited to:
 .. _mailing list: https://lists.clearlinux.org/mailman/listinfo/dev
 
 .. _IRC channel: https://webchat.freenode.net/
+
+.. _doxing: https://en.wikipedia.org/wiki/Doxing

--- a/source/clear-linux/reference/collaboration/community/conduct.rst
+++ b/source/clear-linux/reference/collaboration/community/conduct.rst
@@ -1,0 +1,98 @@
+.. _conduct:
+
+Code of conduct
+###############
+
+The |CLOSIA| community is made up of a mixture of professionals and
+volunteers from all over the world. We strongly believe diversity is our
+strength and want to promote an inclusive and safe environment.
+
+To that end, we have a few ground rules for engaging in the community. The
+following code of conduct applies equally to all community participants,
+including project team leads, core contributors, mentors, users,
+participants, and those seeking help and guidance.
+
+This code of conduct also applies to all spaces the project manages or
+authorizes, including IRC channels, the mailing lists, issue trackers,
+sponsored events, and any other forums the community uses and the project
+manages. In addition, violations of this code of conduct outside of these
+venues may affect a person's ability to participate within them after
+appropriate investigation.
+
+**Be friendly, patient and welcoming.** We strive to be a community that
+welcomes and supports people of all backgrounds and identities. This
+includes, but is not limited to, members of any race, ethnicity, culture,
+national origin, color, immigration status, social and economic class,
+educational level, sex, sexual orientation, gender identity and expression,
+age, size, family status, political belief, religion, and mental and physical
+ability.
+
+**Be considerate.** Our work will be used by other people and we, in turn,
+will depend on the work of others. Any decision we take will affect users and
+colleagues. We should take those consequences into account when making
+decisions. Remember, we are a world-wide community and we have a global base
+of users and contributors. Even if it is not obvious at the time, our
+contributions to the |CL| project will impact the work of others.
+
+**Be respectful.** Not all of us will agree all the time but disagreement is
+no excuse for poor behavior and poor manners. We might all experience some
+frustration now and then but we cannot allow frustration to turn into a
+personal attack. Remember, a community where people feel uncomfortable or
+threatened is not productive. Members of the |CL| community should be
+respectful when dealing with other contributors, people outside of the
+project, and users.
+
+**Collaborate openly.** Collaboration is central to the |CL| project and to
+the larger free software community. This collaboration involves individuals
+working within teams and working with other projects outside of the |CL|
+community. This collaboration reduces redundancy and improves the quality of
+our work. Internally and externally, we should always be open to
+collaboration. Wherever possible, we should work closely with upstream and
+downstream projects and others in the free software community to coordinate
+our technical, advocacy, documentation, and other work. Our work should be
+done transparently and we should involve as many interested parties as early
+as possible. If we decide to take a different approach, we will let them know
+early, document our work, and inform others regularly of our progress. Do not
+create private forms of communication that take away transparency or exclude
+other contributors and collaborators.
+
+**When we disagree, try to understand why.** Disagreements, both social and
+technical, happen all the time and the |CL| community is no exception.
+Resolve disagreements and differing views constructively. Remember, we are
+different. The strength of the community comes from its diversity: people
+from a wide range of backgrounds. Different people have different
+perspectives on issues. Being unable to understand why someone holds a
+viewpoint does not mean they are wrong. Focus on helping resolve issues and
+learning from mistakes. Resolve disagreements and differing views
+constructively and with the help of the community and community processes.
+
+**When we are unsure, we ask for help.** Nobody knows everything and nobody
+is expected to be perfect in the |CL| community. Asking questions avoids many
+problems down the road. So, questions are encouraged. If you are asked
+questions, be responsive and helpful. However, when asking a question, take
+care to do it in an appropriate forum such as the `mailing list`_ or the
+#clearlinux `IRC channel`_.
+
+**Be careful with your words and actions.** We are a community of
+professionals and we conduct ourselves professionally. Do not insult or put
+down other participants. Harassment and other exclusionary behavior is not
+acceptable and should be reported. This includes but is not limited to:
+
+* Violent threats or language directed against another person.
+* Discriminatory jokes and language.
+* Posting sexually suggestive, explicit, or violent material.
+* Posting, or threatening to post, other people's personally identifying
+  information, AKA "doxing".
+* Personal insults, especially those using racist or sexist terms.
+* Unwelcome sexual attention.
+* Advocating for, or encouraging, any of the above behavior.
+* Repeated harassment of others. In general, if someone asks you to stop,
+  then stop.
+
+.. note::
+   Portions of the |CL| code of conduct are derived from the code of conduct
+   of OpenStack\*, the PyCon Conference, and the Django\* Project.
+
+.. _mailing list: https://lists.clearlinux.org/mailman/listinfo/dev
+
+.. _IRC channel: https://webchat.freenode.net/

--- a/source/clear-linux/reference/collaboration/community/irc.rst
+++ b/source/clear-linux/reference/collaboration/community/irc.rst
@@ -5,8 +5,7 @@ IRC channel
 
 The |CLOSIA| team uses an IRC channel for quick chat-like communication. You
 can find it as #clearlinux. You can access the channel through the freenode\*
-`webchat`_ or via IRC applications such as `Pidgin`_\*. Setting up your IRC
-client is beyond the scope of this document.
+`webchat`_ or via IRC applications such as `Pidgin`_\*.
 
 .. _webchat: https://webchat.freenode.net/
 

--- a/source/clear-linux/reference/collaboration/community/irc.rst
+++ b/source/clear-linux/reference/collaboration/community/irc.rst
@@ -1,0 +1,13 @@
+.. _irc:
+
+IRC channel
+###########
+
+The |CLOSIA| team uses an IRC channel for quick chat-like communication. You
+can find it as #clearlinux. You can access the channel through the freenode\*
+`webchat`_ or via IRC applications such as `Pidgin`_\*. Setting up your IRC
+client is beyond the scope of this document.
+
+.. _webchat: https://webchat.freenode.net/
+
+.. _Pidgin: https://pidgin.im/

--- a/source/clear-linux/reference/collaboration/community/irc.rst
+++ b/source/clear-linux/reference/collaboration/community/irc.rst
@@ -4,8 +4,8 @@ IRC channel
 ###########
 
 The |CLOSIA| team uses an IRC channel for quick chat-like communication. You
-can find it as #clearlinux. You can access the channel through the freenode\*
-`webchat`_ or via IRC applications such as `Pidgin`_\*.
+can find our channel as #clearlinux. There are several IRC clients you can
+use including the freenode\* `webchat`_ or the IRC application `Pidgin`_\*.
 
 .. _webchat: https://webchat.freenode.net/
 

--- a/source/clear-linux/reference/collaboration/community/mailing.rst
+++ b/source/clear-linux/reference/collaboration/community/mailing.rst
@@ -12,7 +12,7 @@ work.
   list to:
 
    + Submit :abbr:`RFCs(Requests for Comments)` on planned contributions.
-   + Submit bugs for the team to address.
+   + Submit bugs for the team to address. See :ref:`bug-report`.
    + Ask questions about the |CLOSIA|.
    + Collaborate with developers on new features.
 
@@ -21,7 +21,7 @@ work.
 * Ask your questions directly to the subject matter experts and
   add the mailing list in CC.
 
-* Before doing large amounts of work, send a message detailing your planed
+* Before doing large amounts of work, send a message detailing your planned
   changes to the mailing list as a RFC. Thus, you will save time by only
   working on solutions the community will find useful.
 
@@ -44,6 +44,7 @@ work.
 
 * When submitting bugs, include the steps needed to recreate the issue and
   any relevant information about the system. Use our bug reporting template.
+  See :ref:`bug-report`.
 
 * Do not use capital letters to emphasize a point.
 

--- a/source/clear-linux/reference/collaboration/community/mailing.rst
+++ b/source/clear-linux/reference/collaboration/community/mailing.rst
@@ -1,0 +1,75 @@
+.. _mailing:
+
+Mailing list guidelines
+=======================
+
+These guidelines apply for all emails written to dev@lists.clearlinux.org.
+They ensure communication remains civil, productive, and brief. Use the
+`mailing list`_ effectively and get as much feedback as possible on your
+work.
+
+* Use the mailing list as much as possible. Specifically, use the mailing
+  list to:
+
+   + Submit :abbr:`RFCs(Requests for Comments)` on planned contributions.
+   + Submit bugs for the team to address.
+   + Ask questions about the |CLOSIA|.
+   + Collaborate with developers on new features.
+
+* Provide a meaningful subject line.
+
+* Ask your questions directly to the subject matter experts and
+  add the mailing list in CC.
+
+* Before doing large amounts of work, send a message detailing your planed
+  changes to the mailing list as a RFC. Thus, you will save time by only
+  working on solutions the community will find useful.
+
+* Write briefly and to the point while giving enough context. Keep in mind
+  your message should be clear without readers re-creating your thought
+  process or having to review the same amount of content as you have.
+
+* Be measured but persistent if you are not getting a response.
+
+* Write individual emails for each work item. If they are connected, say so
+  in each email.
+
+* Do not rehash old issues.
+
+* Only reply if you can provide new information, a new perspective, or a
+  decision. Avoid "me-too" posts.
+
+* When replying in-line to a mail that was CC'ed to the list, trim out
+  unnecessary context between replies and at the end of your mail.
+
+* When submitting bugs, include the steps needed to recreate the issue and
+  any relevant information about the system. Use our bug reporting template.
+
+* Do not use capital letters to emphasize a point.
+
+* Make sure your lines are between 72 to 76 characters long.
+
+References
+**********
+
+* General info:
+
+   + http://linux.sgms-centre.com/misc/netiquette.php
+
+   + http://www.ietf.org/rfc/rfc1855.txt
+
+   + http://www.infradead.org/~dwmw2/email.html
+
+   + http://www.arm.linux.org.uk/mailinglists/etiquette.php #e3
+
+   + http://lifehacker.com/5473859/basic-etiquette-for-email-lists-and-forums
+
+* Reasons why top posting is considered harmful:
+
+   + https://lkml.org/lkml/2005/1/11/111
+
+   + http://www.dickgaughan.co.uk/usenet/guide/faq08-topp.html
+
+   + http://www.mail-archive.com/brin-l@coollist.com/msg00178.html
+
+.. _mailing list: https://lists.clearlinux.org/mailman/listinfo/dev

--- a/source/clear-linux/reference/collaboration/community/mailing.rst
+++ b/source/clear-linux/reference/collaboration/community/mailing.rst
@@ -4,9 +4,13 @@ Mailing list guidelines
 =======================
 
 These guidelines apply for all emails written to dev@lists.clearlinux.org.
-They ensure communication remains civil, productive, and brief. Use the
-`mailing list`_ effectively and get as much feedback as possible on your
-work.
+They ensure communication remains civil, productive, and brief. Our goal is
+to use the `mailing list`_ effectively and get as much feedback as possible
+on our work.
+
+In the spirit of open source development, do not send private feedback
+through email. Instead, send feedback to the mailing list by hitting 'Reply-
+to-all' and by keeping the CC list intact.
 
 * Use the mailing list as much as possible. Specifically, use the mailing
   list to:

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -13,4 +13,4 @@ regarding the |CL| project and the |CL| features.
    bundle-commands
    bundles/available-bundles
    compatible-kernels
-   supported-hardware
+   system-requirements

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -9,6 +9,7 @@ regarding the |CL| project and the |CL| features.
 .. toctree::
    :maxdepth: 2
 
+   collaboration/collaboration
    bundle-commands
    bundles/available-bundles
    compatible-kernels


### PR DESCRIPTION
The collaboration guide contain all the information needed to contribute
to the project. The mechanics on how to clone the project's repo are not
included since they will be part of a future addition.

Signed-off-by: Rodrigo Caballero <rodrigo.caballero.abraham@intel.com>