### PR TITLE
Update cpu instruction set requirements

### DIFF
--- a/source/clear-linux/get-started/compatibility-check.rst
+++ b/source/clear-linux/get-started/compatibility-check.rst
@@ -54,7 +54,15 @@ below.
 
       SUCCESS: 64-bit CPU (lm)
 
+      SUCCESS: Supplemental Streaming SIMD Extensions 3 (ssse3)
+
       SUCCESS: Streaming SIMD Extension v4.1 (sse4_1)
+
+      SUCCESS: Streaming SIMD Extensions v4.2 (sse4_2)
+
+      SUCCESS: Advanced Encryption Standard instruction set (aes)
+
+      SUCCESS: Carry-less Multiplication extensions (pclmulqdq)
 
       SUCCESS: EFI Firmware
 

--- a/source/clear-linux/reference/system-requirements.rst
+++ b/source/clear-linux/reference/system-requirements.rst
@@ -32,7 +32,11 @@ minimum requirements include:
    http://ark.intel.com and check for these features:
 
    * Instruction Set = 64-bit
+   * Instruction Set Extensions = SSSE3
    * Instruction Set Extensions = SSE 4.1
+   * Instruction Set Extensions = SSE 4.2
+   * Instruction Set Extensions = AES
+   * Instruction Set Extensions = PCLMUL
 
 *  Memory: 4GB RAM
 


### PR DESCRIPTION
Set requirements to reflect those instructions that gcc will use when
building for the westmere target architecture as that is how Clear
Linux is currently being built.