### PR TITLE
Fix 2 apt-get commands missing "install" option.  

### DIFF
--- a/source/clear-linux/get-started/virtual-machine-install/kvm.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/kvm.rst
@@ -125,13 +125,13 @@ To add :abbr:`GDM (GNOME Display Manager)` to the |CL| VM, follow these steps:
 
      .. code-block:: console
 
-        # apt-get vncviewer
+        # apt-get install vncviewer
 
    * On Mint\* 18.1 “Serena” Desktop:
 
      .. code-block:: console
 
-        # apt-get vncviewer
+        # apt-get install vncviewer
 
    * On Fedora\* 25 Workstation:
 


### PR DESCRIPTION
On 2017-Dec-15:
---------------
Fixed a couple of a apt-get commands that were missing the "install" option.

Signed-off-by: Bun K Tan <bun.k.tan@intel.com>