### PR TITLE
Date was broken, is unnecessary.

### DIFF
--- a/source/clear-linux/reference/bundles/available-bundles.rst
+++ b/source/clear-linux/reference/bundles/available-bundles.rst
@@ -3,8 +3,7 @@
 Available bundles
 #################
 
-This document provides a current list of available `bundles`_ as of
-``[[8 September 2017]]``.
+This document provides a current list of available `bundles`.
 
 See in depth descriptions of the following bundles:
 


### PR DESCRIPTION
This page had a date listed on it for some reason. The hypertext was broken but most of all it is unnecessary.