### PR TITLE
Added note to increase size of VM partition

### DIFF
--- a/source/clear-linux/guides/maintenance/enable-user-space.rst
+++ b/source/clear-linux/guides/maintenance/enable-user-space.rst
@@ -97,9 +97,10 @@ To be able to execute all applications with root privileges, we must add the
 
 Install a GUI to test sudo
 --------------------------
-If you are following this sequence after just setting up the preconfigured
-VMware virtual machine from the repo, you must [increase](./increase-virtual-disk-size#id1) 
-the virtual disk size or the following step will fail. 
+.. note::
+If you are following this sequence after just setting up the pre-configured VMware virtual machine from
+the repo, you must :ref:increase virtual disk size<increase-virtual-disk-size> or the following step
+will fail.
 
 To test the :command:`sudo` command and ensure it is set up correctly,
 install the Gnome Desktop Manager (gdm) and start it.

--- a/source/clear-linux/guides/maintenance/enable-user-space.rst
+++ b/source/clear-linux/guides/maintenance/enable-user-space.rst
@@ -99,7 +99,7 @@ Install a GUI to test sudo
 --------------------------
 .. note::
 If you are following this sequence after just setting up the pre-configured VMware virtual machine from
-the repo, you must :ref:increase virtual disk size<increase-virtual-disk-size> or the following step
+the repo, you must :ref:`increase virtual disk size<increase-virtual-disk-size>` or the following step
 will fail.
 
 To test the :command:`sudo` command and ensure it is set up correctly,

--- a/source/clear-linux/guides/maintenance/enable-user-space.rst
+++ b/source/clear-linux/guides/maintenance/enable-user-space.rst
@@ -97,6 +97,9 @@ To be able to execute all applications with root privileges, we must add the
 
 Install a GUI to test sudo
 --------------------------
+If you are following this sequence after just setting up the preconfigured
+VMware virtual machine from the repo, you must [increase](./increase-virtual-disk-size#id1) 
+the virtual disk size or the following step will fail. 
 
 To test the :command:`sudo` command and ensure it is set up correctly,
 install the Gnome Desktop Manager (gdm) and start it.


### PR DESCRIPTION
I added a note that might confuse new users when following the getting started sequence download, import vmware VM->enable user space. The linux error will not indicate that the hard drive isn't big enough. The link did not render in the preview for some reason so edit it to conform with your relative links convention and build before pulling.