### PR TITLE
Fixed link in telemetry tutorial

### DIFF
--- a/source/clear-linux/tutorials/telemetry-backend/telemetry-backend.rst
+++ b/source/clear-linux/tutorials/telemetry-backend/telemetry-backend.rst
@@ -472,4 +472,4 @@ https://github.com/clearlinux/telemetrics-backend
    https://github.com/clearlinux/telemetrics-backend
 
 .. _`Intel's privacy policies`:
-   http://www.intel.com/content/www/us/en/privacy/intel-privacy.html
+   https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html


### PR DESCRIPTION
Updated the link for intel's privacy policy to https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html