### PR TITLE
Edits installation instructions for accuracy and corrects grammatical…

### DIFF
--- a/source/clear-linux/get-started/bare-metal-install/bare-metal-install.rst
+++ b/source/clear-linux/get-started/bare-metal-install/bare-metal-install.rst
@@ -165,10 +165,8 @@ open a shell, or exit the |CL| installer.  This menu is shown in figure 5:
    installation process and the system will shut down.
 
 #. You will be prompted to join the :guilabel:`Stability Enhancement Program`
-   as shown in figure 6. Press the :kbd:`Spacebar` or :kbd:`Enter` key while
-   the cursor is in the :guilabel:`[ ]  Yes.` button to enable this
-   functionality and then select the :guilabel:`< Next >` button to advance to
-   the next menu item.
+   as shown in figure 6. Press the :kbd:`Spacebar` or :kbd:`Enter` key until
+   the cursor appears in the :guilabel:`[ ] Yes.` button. Press tab to highlight :guilabel:`< Next >`, and select Enter to advance.
 
    .. figure:: figures/bare-metal-install-6.png
       :scale: 50 %
@@ -221,57 +219,61 @@ process. Otherwise, you can follow the |CL| automatic installation steps.
 Clear Linux automatic installation
 **********************************
 
-To install the minimum components for your |CL| implementation, select the
-:guilabel:`< Automatic >` menu item shown in figure 7 and press the
-:kbd:`Enter` key.
+#. To install the minimum components for your |CL| implementation, select the
+   :guilabel:`< Automatic >` menu item shown in figure 7 and press the
+   :kbd:`Enter` key.
 
-The :guilabel:`Choose target device for installation` screen shown in figure 8
-appears.  Move the cursor to the desired target and press the :kbd:`Enter`
-key.
+   The :guilabel:`Choose target device for installation` screen shown in figure 8 appears.  
 
-.. figure:: figures/bare-metal-install-8.png
-   :scale: 50 %
-   :alt: Choose target device for installation
+#. Move the cursor to the desired target and press the :kbd:`Enter`
+   key.
+
+   .. figure:: figures/bare-metal-install-8.png
+      :scale: 50 %
+      :alt: Choose target device for installation
 
    Figure 8: :guilabel:`Choose target device for installation`
 
-In this example we selected the single primary partition from our hard drive.
+   In this example, we selected the single primary partition from our hard drive.
 
-With all the |CL| installer setup information gathered for the automatic
-installation option, the |CL| Installer prompts you to begin the actual
-installation as shown in figure 9.
+   With all the |CL| installer setup information gathered for the automatic
+   installation option, the |CL| Installer prompts you to begin the actual
+   installation as shown in figure 9.
 
-.. figure:: figures/bare-metal-install-9.png
-   :scale: 50 %
-   :alt: Begin installation
+   .. figure:: figures/bare-metal-install-9.png
+      :scale: 50 %
+      :alt: Begin installation
 
    Figure 9: :guilabel:`Begin installation`
 
-When you are satisfied with the information you have entered, select the
-:guilabel:`< Yes >` button and press :kbd:`Enter` to begin installing |CL|.
+#. When you are satisfied with the information you have entered, select the
+   :guilabel:`< Yes >` button and press :kbd:`Enter` to begin installing |CL|.
 
-|CL| Installation begins and each step shows its status as it progresses
-through the automated installation process.
+   |CL| Installation begins and each step shows its status as it progresses
+   through the automated installation process.
 
-Once all steps have completed, you will see the :guilabel:`Successful
-installation` status message and the :guilabel:`< Ok >` button is highlighted
-as shown in figure 10. Press the :kbd:`Enter` key to continue.
+   Once all steps have completed, you will see the :guilabel:`Successful
+   installation` status message and the :guilabel:`< Ok >` button is highlighted as shown in figure 10. 
 
-.. figure:: figures/bare-metal-install-10.png
-   :scale: 50 %
-   :alt: Installation complete
+#. Press the :kbd:`Enter` key to continue.
 
-   Figure 10: :guilabel:`Installation complete`
+   .. figure:: figures/bare-metal-install-10.png
+      :scale: 50 %
+      :alt: Installation complete
 
-Figure 11 shows the installer's final screen prompting you that the
-installation completed successfully and the system will reboot. Press the
-:kbd:`Enter` key and remove the USB media while the system restarts.
+      Figure 10: :guilabel:`Installation complete`
 
-.. figure:: figures/bare-metal-install-11.png
-   :scale: 50 %
-   :alt: Successful installation
+   Figure 11 shows the final installer screen, showing that the
+   installation completed successfully and the system will reboot. 
 
-   Figure 11: :guilabel:`Successful Installation`
+#. Press the :kbd:`Enter` key and remove the USB media while the system 
+   restarts. 
+
+   .. figure:: figures/bare-metal-install-11.png
+      :scale: 50 %
+      :alt: Successful installation
+
+      Figure 11: :guilabel:`Successful Installation`
 
 Set up your root account
 ========================

--- a/source/clear-linux/get-started/bare-metal-install/bare-metal-manual-install.rst
+++ b/source/clear-linux/get-started/bare-metal-install/bare-metal-manual-install.rst
@@ -4,17 +4,17 @@ Bare metal manual installation guide
 ####################################
 
 This section contains the steps for a |CL| manual installation.  It picks up
-where the :ref:`bare-metal-install` left off:
+where the :ref:`bare-metal-install` left off.
 
-Select the :guilabel:`< Manual(Advanced) >` menu option as seen in figure
-1, to do the following additional tasks during the |CL| Installer setup:
+To perform additional tasks during the |CL| Installer setup, select the 
+:guilabel:`< Manual(Advanced) >` menu option (figure 1).  
 
 * :ref:`Modify the disk layout using the cgdisk utility<cgdisk-manual-install>`
 * Add additional command-line parameters to the kernel
 * Create a hostname for your system
 * Create an administrative user
-* Add additional software bundles to enhance the functionality of your initial
-  |CL| installation
+* Add additional software bundles to enhance the functionality of your
+  initial |CL| installation
 * Optionally set up a static IP address for your system
 
 Begin the manual installation process
@@ -29,7 +29,8 @@ Begin the manual installation process
 
    Figure 1: :guilabel:`Choose installation Type`
 
-#. The :guilabel:`Choose partitioning method` screen is shown in figure 2.
+#. The screen :guilabel:`Choose partitioning method` will
+   appear (figure 2).
 
    .. figure:: figures/bare-metal-manual-install-2.png
       :scale: 50 %
@@ -37,10 +38,10 @@ Begin the manual installation process
 
       Figure 2: :guilabel:`Choose partitioning method`
 
-   If your hard drive has already been partitioned for a Linux system, you can
-   select the :guilabel:`< Use default partition and mount scheme on target
-   device >` menu item and press :kbd:`Enter` to move to the next step of the
-   installer setup process.
+   If your hard drive has already been partitioned for a Linux system, you 
+   can select the :guilabel:`< Use default partition and mount scheme on 
+   target device >` menu item and press :kbd:`Enter` to move to the next
+   step of the installer setup process.
 
    .. _cgdisk-manual-setup:
 
@@ -54,8 +55,8 @@ Begin the manual installation process
 Choose target device for installation
 =====================================
 
-The :guilabel:`Choose target device for installation` menu, shown in figure 3,
-displays the current device and partition information. In
+The :guilabel:`Choose target device for installation` menu, shown in figure 
+3, displays the current device and partition information. In
 this example, ``/dev/sda`` is the only drive on the system with three
 partitions defined and assigned. The menu cursor highlights the partition
 to install |CL| onto.
@@ -75,18 +76,20 @@ to install |CL| onto.
 
       Figure 3: :guilabel:`Choose target device for installation`
 
-#. After selecting the :guilabel:`< Partition /dev/sda >` button you will be
-   presented with a warning screen as shown in figure 4 with the
-   :guilabel:`< No >` button highlighted. If you are satisfied this is the
-   device that you want to install |CL| onto, use the :kbd:`Tab` key to
-   highlight the :guilabel:`< Yes >` button and press :kbd:`Enter` to proceed
-   to the next step.
+#. Next, you will be presented with a warning screen (figure 4) with
+   :guilabel:`< No >` highlighted by default. If this is the device onto
+   which you wish to install |CL|, press :kbd:`Tab` to highlight
+   the :guilabel:`< Yes >` button. 
+
+#. Press :kbd:`Enter` to proceed.
 
    .. figure:: figures/bare-metal-manual-install-4.png
       :scale: 50 %
       :alt: Device installation warning
 
       Figure 4: :guilabel:`Device installation warning`
+
+.. _Additional_manual_installer_settings:
 
 Additional manual installer settings
 ====================================
@@ -100,11 +103,11 @@ The next steps of the manual installer setup process allows you to:
 * Optionally create a static IP address for your system.
 
 #. The :guilabel:`Append to kernel cmdline` menu shown in figure 5 allows you
-   to add additional options to the kernel command-line to further customize
-   your installation.  Normally this is not required but if there are
-   specific options that need to be set in the Linux kernel you can enter them
-   here. For a complete list of command-line parameters for the Linux kernel
-   you can visit the official documentation of the `latest kernel's
+   to add more options to the kernel command-line to further customize
+   your installation.  Normally this is not required; however, if there are
+   specific options that need to be set in the Linux kernel, you can enter
+   them here. For a complete list of command-line parameters for the Linux
+   kernel you can visit the official documentation of the `latest kernel's
    command-line parameters`_.
 
    Add any additional command-line parameters in the :guilabel:`Append to
@@ -132,9 +135,10 @@ The next steps of the manual installer setup process allows you to:
    check this `wiki page about hostnames`_.
 
 #. The :guilabel:`User configuration` menu shown in figure 7 allows you to
-   create a userid with administrative privileges. If you do not want to create a
-   user at this time, select :guilabel:`< No user creation (login as root) >` to
-   skip this step and proceed to the :guilabel:`Bundle selector` menu.
+   create a userid with administrative privileges. If you do not want to 
+   create a user at this time, select 
+   :guilabel:`< No user creation (login as root) >` to skip this step and
+   proceed to the :guilabel:`Bundle selector` menu.
 
    .. figure:: figures/bare-metal-manual-install-7.png
       :scale: 50 %
@@ -142,18 +146,19 @@ The next steps of the manual installer setup process allows you to:
 
    Figure 7: :guilabel:`User configuration`
 
-   #. To create a userid, select the :guilabel:`< Create an administrative user >`
-      field and press :kbd:`Enter` to go to the the next screen.
-   #. You will be presented with the second :guilabel:`User configuration` menu
-      shown in figure 8. You are only required to fill in the
-      :guilabel:`Username`, :guilabel:`Password`, and :guilabel:`Confirm password`
-      fields.
-   #. To give the user administrative privileges, select the
-      :guilabel:`Add user to the sudoers?` field to add the user to the ``wheel``
-      group. This enables using the :command:`sudo` command for the new user.
+   #. To create a userid, select the :guilabel:`< Create an administrative 
+      user >` field and press :kbd:`Enter` to go to the the next screen.
+   #. You will be presented with the second :guilabel:`User configuration` 
+      menu shown in figure 8. You are only required to fill in the
+      :guilabel:`Username`, :guilabel:`Password`, and :guilabel:`Confirm 
+      password` fields.
+   #. To give a user administrative privileges, press :kbd:`Tab` until
+      cursor appears in the field :guilabel:`Add user to the sudoers?` and
+      select. This adds the user to the ``wheel`` group and allows entry of 
+      the :command:`sudo` command.
 
-      Once you have entered all the data for this menu, press the :kbd:`Tab` key
-      to highlight the :guilabel:`< Next >` button and press :kbd:`Enter`.
+      After entering all data, press :kbd:`Tab` until :guilabel:`< Next >`
+      is highlighted. Then press :kbd:`Enter`.
 
       .. figure:: figures/bare-metal-manual-install-8.png
          :scale: 50 %
@@ -161,12 +166,11 @@ The next steps of the manual installer setup process allows you to:
 
       Figure 8: :guilabel:`User configuration - create user`
 
-#. The :guilabel:`Bundle selector` menu shown in figure 9 allows you to
-   add additional software bundles to your initial |CL| installation. In this
-   example we select all additional bundles offered by pressing the
-   :kbd:`Tab` key to go to each field and pressing the :kbd:`Spacebar` or the
-   :kbd:`Enter` key to select each bundle. This menu will also list the
-   additional :guilabel:` --- required ---` software bundles that will be
+#. In the menu :guilabel:`Bundle selector` (figure 9), you can add
+   software bundles to your initial |CL| installation. Press the :kbd:`Tab`
+   key to highlight additional bundles, and then press :kbd:`Spacebar` or 
+   :kbd:`Enter` to select each bundle. This menu will also list the
+   additional :guilabel:`--- required ---` software bundles that will be
    installed during the |CL| installation.
 
    .. figure:: figures/bare-metal-manual-install-9.png
@@ -245,11 +249,11 @@ key and remove the USB media while the system restarts.
 Once the system boots, the Gnome Desktop sign-in screen shown in figure 15
 appears:
 
-   .. figure:: figures/bare-metal-manual-install-15.png
-      :scale: 50 %
-      :alt: Gnome sign-in screen
+.. figure:: figures/bare-metal-manual-install-15.png
+   :scale: 50 %
+   :alt: Gnome sign-in screen
 
-      Figure 15: :guilabel:`Gnome sign-in screen`
+   Figure 15: :guilabel:`Gnome sign-in screen`
 
 Click on the :guilabel:`username` you created, enter the password, and you
 will be logged into the system. The Gnome 3 desktop appears as shown in

--- a/source/clear-linux/get-started/bare-metal-install/cgdisk-manual-install.rst
+++ b/source/clear-linux/get-started/bare-metal-install/cgdisk-manual-install.rst
@@ -1,13 +1,12 @@
 .. _cgdisk-manual-install:
 
-Clear Linux partitioning using CGDISK
-#####################################
+Create partitions for Clear Linux\* using CGDISK
+###############################################
 
-These instructions guide you through the initial setup of your hard drive
-partitions using the :command:`cgdisk` utility as part of the |CL| manual
-installation process. If you do not wish to continue creating your own
+As part of the |CL| manual installation processThese instructions guide you through the initial setup of your hard drive
+partitions using the :command:`cgdisk` utility . If you do not wish to continue creating your own
 partitions, :ref:`return to the bare metal manual installation
-<cgdisk-manual-setup>`.
+<bare-metal-manual-install>`.
 
 Prerequisites
 *************
@@ -30,24 +29,24 @@ Partition using CGDISK
 We use the :command:`cgdisk` application to create a
 :abbr:`GPT (GUID Partition Table)` since |CL| only supports the
 :abbr:`UEFI (Unified Extensible Firmware Interface)` specification. For a
-complete description of the :command:`cgdisk` utility and how to use it, visit
-Rod Smith's website for a `GPT fdisk tutorial`_.
+complete description of the :command:`cgdisk` utility and how to use it,
+visit Rod Smith's website for a `GPT fdisk tutorial`_.
 
 In this guide, we intend to use an unpartitioned hard drive for the |CL|
 installation.
 
-#. On the :guilabel:`Choose partitioning method` menu, shown in figure 2,
-   select the :guilabel:`< Manually configure mounts and partitions >` menu
-   item to manually partition your hard drive.
-
+#. To manually partition your hard drive, select 
+   :guilabel:`< Manually configure mounts and partitions >` in the menu
+   :guilabel:`Choose partitioning method`, shown in figure 2. 
+   
    .. figure:: figures/cgdisk-manual-install-2.png
       :scale: 50 %
       :alt: Choose partitioning method
 
       Figure 2: :guilabel:`Choose partitioning method`
 
-   The screen then shows the current device on your system you can partition.
-   In this example, shown in figure 3, :file:`/dev/sda` is available but
+   Next, the current device available to partition is shown. In this
+   example, shown in figure 3, :file:`/dev/sda` is available but
    does not have any partitions defined.
 
 #. Select the :guilabel:`< Partition /dev/sda >` menu item and press
@@ -74,9 +73,9 @@ Linux Partition setup
 In order to properly set up the |CL| partitioning scheme, we create three
 partitions using the :command:`cgdisk` utility in the following order:
 
-  #. EFI boot partition
-  #. Linux swap partition
-  #. Linux root partition
+#. EFI boot partition
+#. Linux swap partition
+#. Linux root partition
 
 For a complete understanding of these partitions, you can review the
 `Linux partitioning scheme`_ information.
@@ -225,7 +224,7 @@ Set the mount points
 ********************
 
 The :guilabel:`Set mount points` menu sets the mount points that the |CL|
-installer uses for your |CL| installation and is shown in figure 12.
+installer uses for your |CL| installation, shown in figure 12.
 
 .. figure:: figures/cgdisk-manual-install-12.png
    :scale: 50 %
@@ -233,21 +232,21 @@ installer uses for your |CL| installation and is shown in figure 12.
 
    Figure 12: :guilabel:`Set mount points`
 
-In this menu you need to set the mount points for the boot and root partitions
-and select to format them.
+In this menu you need to set the mount points for the boot and root
+partitions and select to format them.
 
 #. Highlight the EFI System partition type menu entry and press the
    :kbd:`Enter` key to edit this item. The :guilabel:`Set mount point of
-   sda1` menu is be shown.
+   sda1` menu is shown.
 
-   #. For the :guilabel:`Enter mount point:` type `/boot` and press
+   #. For :guilabel:`Enter mount point:` type `/boot` and press
       :kbd:`Enter`.
-   
-   #. Enable formatting the partition by checking the :guilabel:`[ ] Format`
-      toggle field.
-
-   Figure 13 shows the entered information.  Select the :guilabel:`< Yes >`
-   button and press :kbd:`Enter`.
+   #. Press Tab to enter the :guilabel:`[ ] Format` field. 
+   #. Press Enter/Spacebar to select :guilabel:`[ ] Format`, which allows
+      formatting of the partition. 
+      
+   Figure 13 shows the information entered.  Select :guilabel:`< Next >`
+   and press :kbd:`Enter`.
 
    .. figure:: figures/cgdisk-manual-install-13.png
       :scale: 50 %
@@ -266,7 +265,8 @@ and select to format them.
 
       Figure 14: :guilabel:`Set mount point of sda3`
 
-   The final :guilabel:`Set mount points` menu item looks like figure 15:
+   Upon completion, the :guilabel:`Set mount points` appear as shown
+   in figure 15:
 
    .. figure:: figures/cgdisk-manual-install-15.png
       :scale: 50 %
@@ -274,22 +274,12 @@ and select to format them.
 
       Figure 15: :guilabel:`Set mount points completed`
 
-#. Select the :guilabel:`< Next >` button and press :kbd:`Enter` to proceed to
-   the :guilabel:`Warning!` menu to accept your changes as shown in figure 16.
+#. Select the :guilabel:`< Next >` button and press :kbd:`Enter`. 
    
-   .. figure:: figures/cgdisk-manual-install-16.png
-      :scale: 50 %
-      :alt: Warning
-
-      Figure 16: :guilabel:`Warning`
-
-   Highlight the :guilabel:`< Yes >` button and press :kbd:`Enter` to accept
-   these changes and move on to the next step of the |CL| manual install
-   process.
-
-   This completes the process of manually setting up your hard drive
-   partitions and you can now :ref:`continue with the Clear Linux manual
-   install<choose-target-device>`.
+   You have completed the process of manually partitioning your target
+   system. Now, :ref:`return to the bare metal manual installation 
+   <bare-metal-manual-install>` to complete installation of Clear Linux.
+   Continue at the section *Additional manual installer settings*.
 
 .. _`GPT fdisk tutorial`:
    http://www.rodsbooks.com/gdisk/

--- a/source/clear-linux/get-started/live-image.rst
+++ b/source/clear-linux/get-started/live-image.rst
@@ -26,6 +26,8 @@ Boot the Clear Linux live image
 
 #. Plug the imaged USB drive in and boot it up.
 #. Log in as `root` and set a password.
+   
+.. _create and enable user space: https://clearlinux.org/documentation/clear-linux/guides/maintenance/enable-user-space 
 
 .. _`image`: https://download.clearlinux.org/image
 

--- a/source/clear-linux/get-started/virtual-machine-install/virtualbox.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/virtualbox.rst
@@ -1,34 +1,34 @@
 .. _virtualbox:
 
-Use VirtualBox\*
-################
+Run pre-configured Clear Linux\* as a VirtualBox\* guest OS
+###########################################################
 
-This section explains how to run |CLOSIA| inside a `VirtualBox environment`_.
-
-Please ensure you have enabled `Intel® Virtualization Technology
-<http://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html>`_
-(Intel® VT) and `Intel® Virtualization Technology for Directed I/O
-<https://software.intel.com/en-us/articles/intel-virtualization-technology-for-directed-io-vt-d-enhancing-intel-platforms-for-efficient-virtualization-of-io-devices>`_
-(Intel® VT-d) in your BIOS/UEFI firmware configuration.
+This section shows how to deploy a pre-configured Clear Linux\* image as a guest on the `VirtualBox hypervisor`_ .
 
 Download VirtualBox
 ===================
 
-VirtualBox is a hypervisor supported by Oracle. You can download it from the
-`official VirtualBox website`_ and select the operating system you are using.
-
-Download **version 5.0 or greater** to ensure support for
-the :abbr:`AVX (Advanced Vector Extensions)` needed to run
-|CLOSIA|
-
+VirtualBox\* is a type 2 hypervisor from Oracle. Download and use **version 5.0 or greater** from the `official VirtualBox website`_.
 
 .. _create_vm_vbox:
+
+Install VirtualBox
+===================
+
+#. Enable `Intel® Virtualization Technology`_ (Intel® VT) and
+   `Intel®Virtualization Technology for Directed I/O`_ (Intel® VT-d) in the
+   host machine’s BIOS.
+
+#. Log in and open a terminal emulator.
+
+#. Install VirtualBox on your host machine per the
+   `appropriate instructions`_.
 
 Create a virtual machine in VirtualBox
 ======================================
 
-#. Download the `latest`_ **live** version (clear-XXXX-live.img.xz)
-   from https://download.clearlinux.org/image/. You can also use this command: 
+#. Download the `latest`_ **live** version (clear-XXXX-live.img.xz) of
+   Clear Linux. You can also use this command: 
 
    .. code-block:: bash
 
@@ -38,7 +38,7 @@ Create a virtual machine in VirtualBox
 
    + On Linux ::
 
-       $ xz -d clear-XXXX-live.img.xz
+       xz -d clear-XXXX-live.img.xz
 
    + On Windows you can use `7zip`_.
 
@@ -50,11 +50,11 @@ Create a virtual machine in VirtualBox
 #. To convert a raw image to :abbr:`VDI (VirtualBox Disk Image)`
    format, you can use one of the following commands::
 
-      $ VBoxManage convertfromraw clear-XXXX-live.img clear-XXXX-live.vdi --format VDI
+      VBoxManage convertfromraw clear-XXXX-live.img clear-XXXX-live.vdi --format VDI
 
    or::
 
-      $ vbox-img convert --srcfilename clear-XXXX-live.img --dstfilename clear-XXXX-live.vdi --srcformat raw --dstformat vdi
+      vbox-img convert --srcfilename clear-XXXX-live.img --dstfilename clear-XXXX-live.vdi --srcformat raw --dstformat vdi
 
 
    .. note:: Be sure you have VirtualBox directory in your PATH (i.e., on
@@ -64,7 +64,7 @@ Create a virtual machine in VirtualBox
 
         .. code-block:: console
 
-          set PATH=%PATH%;"C:\Program Files\Oracle\VirtualBox"
+           set PATH=%PATH%;"C:\Program Files\Oracle\VirtualBox"
 
         .. image:: ./figures/vbox-convert-image.png
            :alt: Convert image in Windows command propt
@@ -72,7 +72,8 @@ Create a virtual machine in VirtualBox
 #. Create a virtual machine using the VirtualBox assistant:
 
    a. Type: **Linux**
-   b. Version: **Linux 2.6 / 3.x / 4.x (64-bit)**
+   
+   c. Version: **Linux 2.6 / 3.x / 4.x (64-bit)**
 
       .. image:: ./figures/vbox-create-vm.png
           :alt: Create a new image in VirtualBox
@@ -98,43 +99,46 @@ Create a virtual machine in VirtualBox
 Run your new VM
 ===============
 
-|CLOSIA| supports VirtualBox kernel modules used
-by the Linux kernel 4.9 :abbr:`LTS (Long Term Support)` (*kernel-lts bundle*).
-This kernel was selected because |CL| OS's main kernel
+|CL| supports VirtualBox kernel modules used
+by the Linux kernel 4.9 :abbr:`LTS (Long Term Support)` 
+(*kernel-lts bundle*).This kernel was selected because |CL| OS's main kernel
 (``kernel-native``) bundle keeps up-to-date with the upstream Linux kernel,
 and sometimes VirtualBox kernel modules aren't compatible with pre-kernel
 releases.
 
-In the first boot, |CL| will ask for a login user, type **root** and
-then the system will ask you for a new password.
+On the first boot, |CL| requests a user login.
+
+#. Type **root**. 
+
+#. Enter a new password when prompted. 
 
 To install the VirtualBox kernel modules, here are the steps:
 
 #. Install the bundle that supports VirtualBox modules::
 
-     # swupd bundle-add kernel-lts
+     swupd bundle-add kernel-lts
 
 #. Set a timeout in the bootmanager to shows a menu at boot time::
 
-     # clr-boot-manager set-timeout 10
+     clr-boot-manager set-timeout 10
 
 #. Update the bootloader entries with::
 
-     # clr-boot-manager update
+     clr-boot-manager update
 
 #. Reboot your system with::
 
-     # reboot
+     reboot
 
    and choose **clear-linux-lts-4.9.XX-YYY** kernel version.
 
 #. (*Optional*) Unset timeout to boot directly to LTS version::
 
-     # clr-boot-manager set-timeout 0
+     clr-boot-manager set-timeout 0
 
 #. (*Mandatory*) Update bootmanger to use always LTS version::
 
-     # clr-boot-manager update
+     clr-boot-manager update
 
 
 Install Guest Additions
@@ -151,11 +155,11 @@ VirtualBox Guest Additions, follow these steps:
 
 #. Install Linux users Guest Additions::
 
-     # install-vbox-lga
+     install-vbox-lga
 
 #. Reboot your system::
 
-     # reboot
+     reboot
 
 
 Troubleshooting
@@ -167,7 +171,6 @@ On Windows OS, *VirtualBox* cannot do a **Hardware Virtualization** when
 .. image:: ./figures/vbox-no-vtx.png
    :alt: VirtualBox hardware acceleration error
 
-
 To disable *Hyper-V* you should execute::
 
   bcdedit /set {current} hypervisorlaunchtype off
@@ -178,8 +181,8 @@ To enable Hyper-V again, you should execute::
 
   bcdedit /set {current} hypervisorlaunchtype Auto
 
-
+.. _appropriate instructions: https://www.virtualbox.org/manual/ch02.html
 .. _official VirtualBox website: https://www.virtualbox.org/wiki/Downloads
-.. _VirtualBox environment: https://www.virtualbox.org/
+.. _VirtualBox hypervisor: https://www.virtualbox.org/
 .. _latest: https://download.clearlinux.org/image/
 .. _7zip: http://www.7-zip.org/

--- a/source/clear-linux/guides/maintenance/download-verify-uncompress-linux.rst
+++ b/source/clear-linux/guides/maintenance/download-verify-uncompress-linux.rst
@@ -46,7 +46,7 @@ Uncompress the Clear Linux image
 ********************************
 
 Released |CL| images are compressed with either GNU zip (*.gz*) or XZ
-(*.xz*). The compression type depends on the target platform or image
+(*.xz*). The compression type depends on the target platform or
 environment. To uncompress the image, follow these steps:
 
 #.  Start a terminal emulator.

--- a/source/clear-linux/guides/maintenance/download-verify-uncompress-mac.rst
+++ b/source/clear-linux/guides/maintenance/download-verify-uncompress-mac.rst
@@ -38,15 +38,15 @@ checksum file designated with the suffix `-SHA512SUMS`.
 	  shasum -a512 ./clear-[version number]-[image type].[compression type] | diff ./clear-[version number]-[image type].[compression type]-SHA512SUMS -
 
 If the checksum of the downloaded image is different than the original
-checksum, the differences are displayed. Otherwise, an empty output indicates
+checksum, the differences will be displayed. Otherwise, an empty output indicates
 a match and your downloaded image is good.
 
 Uncompress the Clear Linux image
 ********************************
 
-Released |CL| images are compressed with either GNU zip (*.gz*) or XZ
-(*.xz*). The compression type depends on the target platform or image
-environment. To uncompress the image, follow these steps:
+We compress all released |CL| images by default with either GNU zip 
+(`.gz`) or xz (`.xz`). The compression type we use depends on the target 
+platform or environment. To uncompress the image, follow these steps:
 
 #. Start the Terminal app.
 #. Go to the directory with the downloaded image.

--- a/source/clear-linux/guides/maintenance/download-verify-uncompress-windows.rst
+++ b/source/clear-linux/guides/maintenance/download-verify-uncompress-windows.rst
@@ -43,7 +43,7 @@ Uncompress the Clear Linux image
 ********************************
 
 Released |CL| images are compressed with either GNU zip (*.gz*) or XZ
-(*.xz*). The compression type depends on the target platform or image
+(*.xz*). The compression type depends on the target platform or
 environment. To uncompress the image, follow these steps:
 
 #. Download and install `7-Zip`_.


### PR DESCRIPTION
… errors.

- Corrects minor grammatical errors and simplifies instruction for various installation methods.
- Revises bare-metal-manual-install to correct errors and for readability.
- Revises cgdisk-manual-install
- Adds "on different host systems" to clarify context.
- Revises instruction in Bundle Selector. Fixes in Figure 15.
- Corrects erroneous link in first para to bare-metal-manual-install.
- Omits Figure 16 and following content; directs user to bare-metal-manual-install

Signed-off-by: Michael Vincerra <michaelx.vincerra@intel.com>