### PR TITLE
Rebuilds bundle.html manually combining two scripts:

### DIFF
--- a/source/clear-linux/reference/bundles/bundles.html
+++ b/source/clear-linux/reference/bundles/bundles.html
@@ -57,101 +57,148 @@
     </tr>
    </thead>
    
-   <tbody> 
-    <tr>
+   <tbody>
+   
+   <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/R-basic">R-basic</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p> Run R language programs.
+          <li>Includes (libX11client) bundle.</li></p></td>
+   </tr>
+   
+   <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/R-extras">R-extras</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p> Improve the user experience with a common set of pre-built R libraries.
+          <li>Includes (R-basic) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+        </p></td>
+   </tr>
+   
+   <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/amateur-radio">amateur-radio</a></td>
       <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Applications to support amateur radio operations
+      <td class="bundledesc"><p>Applications to support amateur radio operations.
           <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (libX11client) bundle.</li></p></td>
-    </tr>
+   </tr>
       <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">ansible</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/application-server">application-server</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run an application server via HTTP.
           <li>Includes (web-server-basic) bundle.</li></p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">bc</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/big-data-basic">big-data-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Tools and frameworks for big data management.
           <li>Includes (R-basic) bundle.</li>
           <li>Includes (java-basic) bundle.</li>
-          <li>Includes (python-basic) bundle.</li></p></td>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+        </p></td>
     </tr>
-   <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">bmap-tools</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/bootloader">bootloader</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Loads kernel from disk and boots the system.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/bootloader-extras">bootloader-extras</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Extra packages to decrypt root partition.</p></td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/c-basic">c-basic</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/c-basic">c-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run C/C++ language programs.</p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">clamav</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/cloud-control">cloud-control</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a cloud orchestration server.
           <li>Includes (kvm-host) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
           <li>Includes (network-basic) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li>
-          <li>Includes (storage-cluster) bundle.</li></p></td>
+          </p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/cloud-native-basic">cloud-native-basic</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Contains ClearLinux native software for Cloud.
-          <li>Includes (containers-virt) bundle.</li></p></td>
+          <li>Includes (containers-basic) bundle.</li>
+          <li>Includes (containers-virt) bundle.</li>
+          <li>Includes (kernel-container) bundle.</li>
+     </p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/clr-devops">clr-devops</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run all Clear Linux devops workloads.
-          <li>Includes (os-installer) bundle.</li>
-          <li>Includes (os-core-update) bundle.</li>
-          <li>Includes (mixer) bundle.</li>
           <li>Includes (java-basic) bundle.</li>
-          <li>Includes (rust-basic) bundle.</li>
           <li>Includes (koji) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (mixer) bundle.</li>
+          <li>Includes (os-core-update) bundle.</li>                          
+          <li>Includes (os-installer) bundle.</li>
+          <li>Includes (package-utils) bundle.</li>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (rust-basic) bundle.</li>
           <li>Includes (scm-server) bundle.</li>
-          <li>Includes (web-server-basic) bundle.</li></p></td>
+          <li>Includes (sysadmin-basic) bundle.</li>
+          <li>Includes (web-server-basic) bundle.</li>
+        </p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">cockpit</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-basic">containers-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run container applications from Dockerhub.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-basic-dev">containers-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
@@ -160,169 +207,245 @@
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-virt">containers-virt</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run container applications from Dockerhub in lightweight virtual machines.
-          <li>Includes (kernel-container) bundle.</li>
-          <li>Includes (containers-basic) bundle.</li></p></td>
+          <li>Includes (containers-basic) bundle.</li> 
+          <li>Includes (kernel-container) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-virt-dev">containers-virt-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the containers-virt bundle.
+          <li>Includes (containers-basic) bundle.</li>          
           <li>Includes (containers-basic-dev) bundle.</li>
           <li>Includes (containers-virt) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li></p></td>
+          <li>Includes (kernel-container) bundle.</li>
+          <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">cpio</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/cryptography">cryptography</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Encrypt, decrypt, sign and verify objects.</p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">curl</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">darktable</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/database-basic">database-basic</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/database-basic">database-basic</a></td>
       <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Run a SQL database.</p></td>
+      <td class="bundledesc"><p>Run an SQL database.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/database-basic-dev">database-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the database-basic bundle.
           <li>Includes (database-basic) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li></p></td>
+          <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop">desktop</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/desktop">desktop</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the GNOME GUI desktop environment.
-          <li>Includes (libX11client) bundle.</li>
           <li>Includes (desktop-apps) bundle.</li>
-          <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (desktop-assets) bundle.</li>
+          <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (desktop-locales) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
           <li>Includes (sysadmin-basic) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-apps">desktop-apps</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Applications for the desktop.
-          <li>Includes (libX11client) bundle.</li>
           <li>Includes (desktop-gnomelibs) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-apps-extras">desktop-apps-extras</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Larger set of applications for the desktop.
           <li>Includes (desktop-gnomelibs) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>          
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-assets">desktop-assets</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Images and Icons for the desktop.
-          <li>Includes (desktop-gnomelibs) bundle.</li></p></td>
+          <li>Includes (desktop-gnomelibs) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>           
+        </p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-autostart">desktop-autostart</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Bundle to cause the UI to automatically start at boot.
-          <li>Includes (desktop) bundle.</li></p></td>
+          <li>Includes (desktop) bundle.</li>
+          <li>Includes (desktop-apps) bundle.</li>
+          <li>Includes (desktop-assets) bundle.</li>
+          <li>Includes (desktop-gnomelibs) bundle.</li>       
+          <li>Includes (desktop-locales) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (sysadmin-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-dev">desktop-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the desktop bundle.
           <li>Includes (desktop) bundle.</li>
-          <li>Includes (dev-utils) bundle.</li>
+          <li>Includes (desktop-apps) bundle.</li>
+          <li>Includes (desktop-assets) bundle.</li>
+          <li>Includes (desktop-dev) bundle.</li>
+          <li>Includes (desktop-gnomelibs) bundle.</li>       
+          <li>Includes (desktop-locales) bundle.</li>
+          <li>Includes (dev-utils) bundle.</li>   
+          <li>Includes (libX11client) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (sysadmin-basic-dev) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>            
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (sysadmin-basic) bundle.</li>
+          <li>Includes (sysadmin-basic-dev) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-gnomelibs">desktop-gnomelibs</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Helper bundle with common libraries used by desktopy things.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
+    
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/desktop-i3">desktop-i3</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p></p></td>
+    </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-locales">desktop-locales</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Translations and documentation for desktop components.</p></td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/dev-utils">dev-utils</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/dev-utils">dev-utils</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Assist application development.
           <li>Includes (perl-basic) bundle.</li>
-          <li>Includes (python3-basic) bundle.</li></p></td>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/dev-utils-dev">dev-utils-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the dev-utils bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (perl-basic-dev) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (perl-basic-dev) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
-      <tr>
+
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">dfu-util</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/dhcp-server">dhcp-server</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a dhcp server.</p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">diffoscope</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">dtc</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/editors">editors</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run popular terminal text editors.
-          <li>Includes (vim) bundle.</li>
-          <li>Includes (emacs) bundle.</li></p></td>
+          <li>Includes (emacs) bundle.</li> 
+          <li>Includes (perl-basic-dev) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (vim) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/editors-dev">editors-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the editors bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (editors) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li></p></td>
+          <li>Includes (emacs) bundle.</li> 
+          <li>Includes (os-core-dev) bundle.</li>          
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (vim) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/emacs">emacs</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/emacs">emacs</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>The popular emacs terminal text editor.</p></td>
     </tr>
-      <tr>
+
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">file</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
@@ -332,293 +455,372 @@
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">firefox</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p></p></td>
-    </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">fio</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">firefox</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p></p></td>
+    </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/games">games</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Play games in Clear Linux.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/games-dev">games-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the games bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (games) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li></p></td>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">gimp</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">git</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/go-basic">go-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run go language programs.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/go-basic-dev">go-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the go-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (go-basic) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li></p></td>
+          <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+        </p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">gzip</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/hardware-bluetooth">hardware-bluetooth</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/hardware-bluetooth">hardware-bluetooth</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Software to enable use of bluetooth hardware.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/haskell-basic">haskell-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run haskell language programs.
-          <li>Includes (perl-basic) bundle.</li>
-          <li>Includes (c-basic) bundle.</li></p></td>
+          <li>Includes (c-basic) bundle.</li>   
+          <li>Includes (perl-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/hpc-utils">hpc-utils</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Provide userspace management programs for various HPC related programs.
           <li>Includes (perl-basic) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">htop</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">httpd</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">hugo</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">icdiff</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">inotify-tools</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">irssi</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-    <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java9-basic">java9-basic</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Build and run java9 language programs.
-          <li>Includes (libX11client) bundle.</li>
-          <li>Includes (python-basic) bundle.</li></p></td>
-    </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java-basic">java-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run java language programs.
           <li>Includes (libX11client) bundle.</li>
-          <li>Includes (python-basic) bundle.</li></p></td>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java-runtime">java-runtime</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run java language programs.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
-      <tr>
+
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java9-basic">java9-basic</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p>Build and run java9 language programs.
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (python-basic) bundle.</li>                  
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
+    </tr>
+  
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">joe</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">jq</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-aws">kernel-aws</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the kvm specific kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-container">kernel-container</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the container specific kernel.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-gce">kernel-gce</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the kvm specific kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-hyperv">kernel-hyperv</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the hyperv specific kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-hyperv-lts">kernel-hyperv-lts</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the hyperv specific LTS kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-hyperv-mini">kernel-hyperv-mini</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the hyperv mini-os specific kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-kvm">kernel-kvm</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the kvm specific kernel.
           <li>Includes (bootloader) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-lts">kernel-lts</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the lts native kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-native">kernel-native</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the native kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-oracle">kernel-oracle</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the Oracle Cloud specific kernel.
-          <li>Includes (bootloader) bundle.</li></p></td>
+          <li>Includes (bootloader) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-pk">kernel-pk</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the Intel "PK" kernel, and enterprise-style kernel with backports.
           <li>Includes (bootloader) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/koji">koji</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Sets up a koji build service based on NFS mounts.
           <li>Includes (package-utils) bundle.</li>
           <li>Includes (python-basic) bundle.</li>
-          <li>Includes (web-server-basic) bundle.</li></p></td>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (web-server-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kvm-host">kvm-host</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run virtual machines.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/letsencrypt-client">letsencrypt-client</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Obtain and renew valid SSL certificates through Let's Encrypt's ACME service.
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/libX11client">libX11client</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/libX11client">libX11client</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Grouping only bundle for use in X using bundles.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">linux-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">linux-tools</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/machine-learning-basic">machine-learning-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build machine learning applications.
           <li>Includes (c-basic) bundle.</li>
-          <li>Includes (python-extras) bundle.</li></p></td>
+          <li>Includes (python) bundle.</li>
+          <li>Includes (python-extras) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/machine-learning-web-ui">machine-learning-web-ui</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Web based, interactive tools for machine learning.
-          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (R-basic) bundle.</li> 
           <li>Includes (R-extras) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/mail-utils">mail-utils</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Process, read and send email
           <li>Includes (python2-basic) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/mail-utils-dev">mail-utils-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the mail-utils bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (mail-utils) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li></p></td>
+          <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/mixer">mixer</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Create Clear Linux releases.
           <li>Includes (os-installer) bundle.</li>
-          <li>Includes (python-basic) bundle.</li>
-          <li>Includes (sysadmin-basic) bundle.</li></p></td>
+          <li>Includes (python-basic) bundle.</li>          
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (sysadmin-basic) bundle.</li></p>
+        </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">mkosi</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/network-basic">network-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run network utilities and modify network settings.
-          <li>Includes # bundle.</li>
-          <li>Includes perl-basic bundle.</li>
-          <li>Includes and bundle.</li>
-          <li>Includes tcl-basic bundle.</li>
-          <li>Includes d bundle.</li>
-          <li>Includes to bundle.</li>
-          <li>Includes avoid bundle.</li>
-          <li>Includes duplication bundle.</li>
           <li>Includes (perl-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/network-basic-dev">network-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
@@ -626,67 +828,85 @@
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (network-basic) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (perl-basic-dev) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (perl-basic-dev) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">nginx</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/nodejs-basic">nodejs-basic</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/nodejs-basic">nodejs-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run javascript server side.</p></td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/openssh-server">openssh-server</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/openssh-server">openssh-server</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run an ssh server.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">openssl</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-clear-containers">os-clear-containers</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Control Clear Containers guest setup and workloads.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest">os-cloudguest</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run any initialization processes required of a generic cloud guest VM.
           <li>Includes (openssh-server) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-aws">os-cloudguest-aws</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required of an AWS cloud guest VM.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-azure">os-cloudguest-azure</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run any initialization process requried of an Azure cloud guest VM.
           <li>Includes (openssh-server) bundle.</li>
-          <li>Includes (python-basic) bundle.</li></p></td>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-gce">os-cloudguest-gce</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required of an GCE cloud guest VM.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-oracle">os-cloudguest-oracle</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required of an Oracle Cloud guest.
           <li>Includes (openssh-server) bundle.</li></p></td>
     </tr>
+    
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-vmware">os-cloudguest-vmware</a></td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/os-cloudguest-vmware">os-cloudguest-vmware</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required for VMWare VMs.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-clr-on-clr">os-clr-on-clr</a></td>
       <td class="bundlestatus">Active</td>
@@ -695,326 +915,456 @@
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (dev-utils-dev) bundle.</li>
           <li>Includes (editors) bundle.</li>
+          <li>Includes (emacs) bundle.</li>
           <li>Includes (go-basic) bundle.</li>
           <li>Includes (koji) bundle.</li>
           <li>Includes (kvm-host) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
           <li>Includes (mail-utils) bundle.</li>
           <li>Includes (mail-utils-dev) bundle.</li>
           <li>Includes (mixer) bundle.</li>
           <li>Includes (network-basic) bundle.</li>
           <li>Includes (network-basic-dev) bundle.</li>
           <li>Includes (openssh-server) bundle.</li>
-          <li>Includes (os-core) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
           <li>Includes (os-core-update-dev) bundle.</li>
+          <li>Includes (os-installer) bundle.</li>
+          <li>Includes (package-utils) bundle.</li>
           <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (perl-basic-dev) bundle.</li>
           <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
           <li>Includes (storage-utils) bundle.</li>
           <li>Includes (storage-utils-dev) bundle.</li>
           <li>Includes (sysadmin-basic) bundle.</li>
-          <li>Includes (sysadmin-basic-dev) bundle.</li></p></td>
+          <li>Includes (sysadmin-basic-dev) bundle.</li>
+          <li>Includes (vim) bundle.</li>
+          <li>Includes (web-server-basic) bundle.</li></p>
+        </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-clr-on-clr-dev">os-clr-on-clr-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-clr-on-clr bundle.
+          <li>Includes (c-basic) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (dev-utils-dev) bundle.</li>
+          <li>Includes (editors) bundle.</li>
           <li>Includes (editors-dev) bundle.</li>
+          <li>Includes (emacs) bundle.</li>
+          <li>Includes (go-basic) bundle.</li>
           <li>Includes (go-basic-dev) bundle.</li>
+          <li>Includes (koji) bundle.</li>
+          <li>Includes (kvm-host) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (mail-utils) bundle.</li>
           <li>Includes (mail-utils-dev) bundle.</li>
+          <li>Includes (mixer) bundle.</li>
+          <li>Includes (network-basic) bundle.</li>
           <li>Includes (network-basic-dev) bundle.</li>
-          <li>Includes (os-clr-on-clr) bundle.</li>
+          <li>Includes (openssh-server) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (os-core-update-dev) bundle.</li>
+          <li>Includes (os-installer) bundle.</li>
+          <li>Includes (package-utils) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>
           <li>Includes (perl-basic-dev) bundle.</li>
+          <li>Includes (python-basic) bundle.</li>
           <li>Includes (python-basic-dev) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (storage-utils) bundle.</li>
           <li>Includes (storage-utils-dev) bundle.</li>
-          <li>Includes (sysadmin-basic-dev) bundle.</li></p></td>
+          <li>Includes (sysadmin-basic) bundle.</li>
+          <li>Includes (sysadmin-basic-dev) bundle.</li>
+          <li>Includes (vim) bundle.</li>
+          <li>Includes (web-server-basic) bundle.</li></p>
+        </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core">os-core</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a minimal Linux userspace.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core-dev">os-core-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-core bundle.
-          <li>Includes (dev-utils) bundle.</li></p></td>
+          <li>Includes (dev-utils) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>          
+          <li>Includes (python3-basic) bundle.</li></p> 
+      </td>              
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core-update">os-core-update</a></td>
       <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Provides basic suite for running the Clear Linux for iA Updater.
-          <li>Includes (os-core) bundle.</li></p></td>
+      <td class="bundledesc"><p>Provides basic suite for running the Clear Linux for iA Updater.</p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core-update-dev">os-core-update-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-core-update bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (os-core-update) bundle.</li></p></td>
+          <li>Includes (os-core-update) bundle.</li>
+          <li>Includes (os-core-update-dev) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>          
+          <li>Includes (python3-basic) bundle.</li></p>
+       </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-installer">os-installer</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run image creation and installation for Clear Linux.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-testsuite">os-testsuite</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides minimal functionality for core testing functions.
           <li>Includes (openssh-server) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-testsuite-phoronix">os-testsuite-phoronix</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the Phoronix testsuite.
+          <li>Includes (R-basic) bundle.</li>          
           <li>Includes (c-basic) bundle.</li>
           <li>Includes (database-basic) bundle.</li>
-          <li>Includes (go-basic) bundle.</li>
-          <li>Includes (machine-learning-basic) bundle.</li>
-          <li>Includes (desktop-autostart) bundle.</li>
+          <li>Includes (desktop) bundle.</li>
+          <li>Includes (desktop-apps) bundle.</li>          
           <li>Includes (desktop-apps-extras) bundle.</li>
-          <li>Includes (php-basic) bundle.</li>
+          <li>Includes (desktop-assets) bundle.</li>
+          <li>Includes (desktop-autostart) bundle.</li>          
+          <li>Includes (desktop-gnomelibs) bundle.</li>
+          <li>Includes (desktop-locales) bundle.</li>
           <li>Includes (games) bundle.</li>
-          <li>Includes (R-basic) bundle.</li></p></td>
+          <li>Includes (go-basic) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (machine-learning-basic) bundle.</li> 
+          <li>Includes (php-basic) bundle.</li>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python-extras) bundle.</li>          
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (sysadmin-basic) bundle.</li></p>
+        </td>            
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-utils-gui">os-utils-gui</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides a graphical desktop environment.
           <li>Includes (cryptography) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>          
           <li>Includes (python-basic) bundle.</li>
-          <li>Includes (xfce4-desktop) bundle.</li></p></td>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (xfce4-desktop) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-utils-gui-dev">os-utils-gui-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-utils-gui bundle.
+          <li>Includes (cryptography) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>          
           <li>Includes (os-core-dev) bundle.</li>
           <li>Includes (os-utils-gui) bundle.</li>
-          <li>Includes (python-basic-dev) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>     
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python-basic-dev) bundle.</li>          
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (xfce4-desktop) bundle.</li></p>
+    </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/package-utils">package-utils</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Utilities for creating, building, and managing packages.
-          <li>Includes (python3-basic) bundle.</li></p></td>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">parallel</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">patch</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/performance-tools">performance-tools</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run performance and power measurements.
+          <li>Includes (libX11client) bundle.</li>            
           <li>Includes (perl-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li>
-          <li>Includes (tcl-basic) bundle.</li></p></td>
+          <li>Includes (tcl-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/perl-basic">perl-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run perl language programs.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/perl-basic-dev">perl-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the perl-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (perl-basic) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/perl-extras">perl-extras</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Improve user experience with a common set of pre-built perl libraries.
-          <li>Includes (perl-basic) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li></p>
+      </td>
     </tr>
-    <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">pmdk</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p></p></td>
-    </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/php-basic">php-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run php language programs.</p></td>
     </tr>
+
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">pmdk</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p></p></td>
+    </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/pnp-tools-basic">pnp-tools-basic</a></td>
       <td class="bundlestatus">Deprecated</td>
       <td class="bundledesc"><p>Run performance and power measurements.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">postgresql</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
+
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">powertop</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>    
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/productivity">productivity</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>A set of console utilities for task management and communication.
           <li>Includes (mail-utils) bundle.</li>
-          <li>Includes (python3-basic) bundle.</li></p></td>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+        </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/pxe-server">pxe-server</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a PXE server.</p></td>
     </tr>
-    <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python2-basic">python2-basic</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Run legacy python language programs.</p></td>
-    </tr>
-    <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python3-basic">python3-basic</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Run python language programs.</p></td>
-    </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python-basic">python-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run python language programs.
           <li>Includes (python2-basic) bundle.</li>
-          <li>Includes (python3-basic) bundle.</li></p></td>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python-basic-dev">python-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the python-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (python-basic) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>          
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python-basic-dev) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python-extras">python-extras</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Improve user experience with a common set of pre-built python libraries.
           <li>Includes (python-basic) bundle.</li>
-          <li>Includes (python3-basic) bundle.</li></p></td>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python2-basic">python2-basic</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p>Run legacy python language programs.</p></td>
+    </tr>
+    
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python3-basic">python3-basic</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p>Run python language programs.</p></td>
+    </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/qt-basic">qt-basic</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run programs that use the QT runtime.
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/qt-basic-dev">qt-basic-dev</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>All packages required to build the qt-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (qt-basic) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (qt-basic) bundle.</li></p>
+      </td>
     </tr>
-    <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/R-basic">R-basic</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Run R language programs.
-          <li>Includes (libX11client) bundle.</li></p></td>
-    </tr>
-    <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/R-extras">R-extras</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Improve the user experience with a common set of pre-built R libraries.
-          <li>Includes (R-basic) bundle.</li></p></td>
-    </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/ruby-basic">ruby-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run ruby language programs.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/rust-basic">rust-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run rust language programs.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/scm-server">scm-server</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run a source code management server.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/service-os">service-os</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides the needed software for Service OS.
           <li>Includes (bootloader) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/shells">shells</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a shell.</p></td>
     </tr>
+
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/software-defined-cockpit">software-defined-cockpit</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p> Run the automotive software defined cockpit which has graphic, media, sound and connectivity.</p>
+      </td>
+    </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/storage-cluster">storage-cluster</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a storage server.
           <li>Includes (python3-basic) bundle.</li>
-          <li>Includes (python2-basic) bundle.</li></p></td>
+          <li>Includes (python2-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/storage-utils">storage-utils</a></td>
       <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Run disk and filesystem management functions.</p></td>
+      <td class="bundledesc"><p>Run disk and file system management functions.</p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/storage-utils-dev">storage-utils-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the storage-utils bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (storage-utils) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>          
+          <li>Includes (storage-utils) bundle.</li></p>
+        </td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">strace</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/stream-server">stream-server</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run an audio or visual streaming server.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">subversion</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
-      <tr>
+    
+    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">suricata</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-basic">sysadmin-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run common utilities useful for managing a system.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-basic-dev">sysadmin-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the sysadmin-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
-          <li>Includes (os-core-dev) bundle.</li>
-          <li>Includes (sysadmin-basic) bundle.</li></p></td>
+          <li>Includes (os-core-dev) bundle.</li>       
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>   
+          <li>Includes (sysadmin-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-hostmgmt">sysadmin-hostmgmt</a></td>
       <td class="bundlestatus">Active</td>
@@ -1022,128 +1372,182 @@
           <li>Includes (pxe-server) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-remote">sysadmin-remote</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Enable the host to be managed remotely by configuration management tools.
           <li>Includes (openssh-server) bundle.</li>
-          <li>Includes (python-basic) bundle.</li></p></td>
+          <li>Includes (python-basic) bundle.</li>
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">systemd-cryptsetup</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/tcl-basic">tcl-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run tk/tcl language programs.
-          <li>Includes (libX11client) bundle.</li></p></td>
+          <li>Includes (libX11client) bundle.</li></p>
+      </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/telemetrics">telemetrics</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run telemetrics client.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">thunderbird</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/time-server-basic">time-server-basic</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run an NTP server.</p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">tmux</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">unzip</a></td>
       <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p></p></td>
+      <td class="bundledesc"><p></p>
+    </td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/user-basic">user-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Meta bundle capturing most console user work flows.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (editors) bundle.</li>
+          <li>Includes (emacs) bundle.</li>
           <li>Includes (kvm-host) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
           <li>Includes (mail-utils) bundle.</li>
           <li>Includes (network-basic) bundle.</li>
           <li>Includes (openssh-server) bundle.</li>
           <li>Includes (os-core-update) bundle.</li>
+          <li>Includes (perl-basic) bundle.</li>          
+          <li>Includes (python2-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
           <li>Includes (shells) bundle.</li>
           <li>Includes (storage-utils) bundle.</li>
-          <li>Includes (sysadmin-basic) bundle.</li></p></td>
+          <li>Includes (sysadmin-basic) bundle.</li>
+          <li>Includes (vim) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/user-basic-dev">user-basic-dev</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the user-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (dev-utils-dev) bundle.</li>
+          <li>Includes (editors) bundle.</li>
           <li>Includes (editors-dev) bundle.</li>
+          <li>Includes (emacs) bundle.</li>
+          <li>Includes (kvm-host) bundle.</li>
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (mail-utils) bundle.</li>  
           <li>Includes (mail-utils-dev) bundle.</li>
+          <li>Includes (network-basic) bundle.</li>          
           <li>Includes (network-basic-dev) bundle.</li>
+          <li>Includes (openssh-server) bundle.</li>          
           <li>Includes (os-core-dev) bundle.</li>
+          <li>Includes (os-core-update) bundle.</li>
           <li>Includes (os-core-update-dev) bundle.</li>
-          <li>Includes (storage-utils-dev) bundle.</li>
-          <li>Includes (sysadmin-basic-dev) bundle.</li>
-          <li>Includes (user-basic) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">valgrind</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/vim">vim</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>The popular vim text editor
-          <li>Includes (python3-basic) bundle.</li>
-          <li>Includes (perl-basic) bundle.</li></p></td>
+          <li>Includes (perl-basic) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">vlc</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/vnc-server">vnc-server</a></td>
       <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Enable the host to be a vnc desktop server.
           <li>Includes (desktop) bundle.</li>
-          <li>Includes (openssh-server) bundle.</li></p></td>
+          <li>Includes (desktop-apps) bundle.</li>          
+          <li>Includes (desktop-assets) bundle.</li>          
+          <li>Includes (desktop-gnomelibs) bundle.</li>          
+          <li>Includes (desktop-locales) bundle.</li>          
+          <li>Includes (libX11client) bundle.</li>
+          <li>Includes (openssh-server) bundle.</li>
+          <li>Includes (python3-basic) bundle.</li>
+          <li>Includes (sysadmin-basic) bundle.</li></p>
+      </td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/web-server-basic">web-server-basic</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a HTTP web server.</p></td>
     </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">weechat</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
+    <tr>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">wireshark</a></td>
+      <td class="bundlestatus">Active</td>
+      <td class="bundledesc"><p></p></td>
+    </tr>
+
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/xfce4-desktop">xfce4-desktop</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run GUI desktop environment.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">xz</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+    
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">zsh</a></td>
       <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
+
  </tbody> 
 </table>

--- a/source/clear-linux/reference/bundles/bundles.html
+++ b/source/clear-linux/reference/bundles/bundles.html
@@ -52,7 +52,6 @@
    <thead>
     <tr>
       <th align=left>Bundle Name</th>
-      <th align=center>Status</th>
       <th align=left>Description</th>
     </tr>
    </thead>
@@ -61,14 +60,12 @@
    
    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/R-basic">R-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p> Run R language programs.
           <li>Includes (libX11client) bundle.</li></p></td>
    </tr>
    
    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/R-extras">R-extras</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p> Improve the user experience with a common set of pre-built R libraries.
           <li>Includes (R-basic) bundle.</li>
           <li>Includes (libX11client) bundle.</li>
@@ -77,33 +74,28 @@
    
    <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/amateur-radio">amateur-radio</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Applications to support amateur radio operations.
           <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (libX11client) bundle.</li></p></td>
    </tr>
       <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">ansible</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/application-server">application-server</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run an application server via HTTP.
           <li>Includes (web-server-basic) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">bc</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/big-data-basic">big-data-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Tools and frameworks for big data management.
           <li>Includes (R-basic) bundle.</li>
           <li>Includes (java-basic) bundle.</li>
@@ -116,37 +108,31 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">bmap-tools</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/bootloader">bootloader</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Loads kernel from disk and boots the system.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/bootloader-extras">bootloader-extras</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Extra packages to decrypt root partition.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/c-basic">c-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run C/C++ language programs.</p></td>
     </tr>
     
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">clamav</a></td>
-      <td class="bundlestatus">Active</td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">clamav</a></td>      
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/cloud-control">cloud-control</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a cloud orchestration server.
           <li>Includes (kvm-host) bundle.</li>
           <li>Includes (libX11client) bundle.</li>
@@ -158,7 +144,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/cloud-native-basic">cloud-native-basic</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Contains ClearLinux native software for Cloud.
           <li>Includes (containers-basic) bundle.</li>
           <li>Includes (containers-virt) bundle.</li>
@@ -168,7 +153,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/clr-devops">clr-devops</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run all Clear Linux devops workloads.
           <li>Includes (java-basic) bundle.</li>
           <li>Includes (koji) bundle.</li>
@@ -183,25 +167,23 @@
           <li>Includes (rust-basic) bundle.</li>
           <li>Includes (scm-server) bundle.</li>
           <li>Includes (sysadmin-basic) bundle.</li>
-          <li>Includes (web-server-basic) bundle.</li>
-        </p></td>
+          <li>Includes (web-server-basic) bundle.</li></p>
+      </td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">cockpit</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-basic">containers-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run container applications from Dockerhub.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-basic-dev">containers-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
+      
       <td class="bundledesc"><p>All packages required to build the containers-basic bundle.
           <li>Includes (containers-basic) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
@@ -210,7 +192,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-virt">containers-virt</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run container applications from Dockerhub in lightweight virtual machines.
           <li>Includes (containers-basic) bundle.</li> 
           <li>Includes (kernel-container) bundle.</li></p>
@@ -219,7 +200,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/containers-virt-dev">containers-virt-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the containers-virt bundle.
           <li>Includes (containers-basic) bundle.</li>          
           <li>Includes (containers-basic-dev) bundle.</li>
@@ -234,37 +214,31 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">cpio</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/cryptography">cryptography</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Encrypt, decrypt, sign and verify objects.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">curl</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">darktable</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/database-basic">database-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run an SQL database.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/database-basic-dev">database-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the database-basic bundle.
           <li>Includes (database-basic) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
@@ -276,7 +250,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/desktop">desktop</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the GNOME GUI desktop environment.
           <li>Includes (desktop-apps) bundle.</li>
           <li>Includes (desktop-assets) bundle.</li>
@@ -289,7 +262,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-apps">desktop-apps</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Applications for the desktop.
           <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (libX11client) bundle.</li>
@@ -298,7 +270,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-apps-extras">desktop-apps-extras</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Larger set of applications for the desktop.
           <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (libX11client) bundle.</li>          
@@ -307,7 +278,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-assets">desktop-assets</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Images and Icons for the desktop.
           <li>Includes (desktop-gnomelibs) bundle.</li>
           <li>Includes (libX11client) bundle.</li>           
@@ -317,7 +287,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-autostart">desktop-autostart</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Bundle to cause the UI to automatically start at boot.
           <li>Includes (desktop) bundle.</li>
           <li>Includes (desktop-apps) bundle.</li>
@@ -332,7 +301,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-dev">desktop-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the desktop bundle.
           <li>Includes (desktop) bundle.</li>
           <li>Includes (desktop-apps) bundle.</li>
@@ -352,26 +320,22 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-gnomelibs">desktop-gnomelibs</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Helper bundle with common libraries used by desktopy things.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/desktop-i3">desktop-i3</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/desktop-locales">desktop-locales</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Translations and documentation for desktop components.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/dev-utils">dev-utils</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Assist application development.
           <li>Includes (perl-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p>
@@ -380,7 +344,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/dev-utils-dev">dev-utils-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the dev-utils bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
@@ -392,31 +355,26 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">dfu-util</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/dhcp-server">dhcp-server</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a dhcp server.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">diffoscope</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">dtc</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/editors">editors</a></td>
-      <td class="bundlestatus">Active</td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/editors">editors</a></td>   
       <td class="bundledesc"><p>Run popular terminal text editors.
           <li>Includes (emacs) bundle.</li> 
           <li>Includes (perl-basic-dev) bundle.</li>
@@ -426,8 +384,7 @@
     </tr>
 
     <tr>
-      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/editors-dev">editors-dev</a></td>
-      <td class="bundlestatus">Active</td>
+      <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/editors-dev">editors-dev</a></td>      
       <td class="bundledesc"><p>All packages required to build the editors bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (editors) bundle.</li>
@@ -441,43 +398,36 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/emacs">emacs</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>The popular emacs terminal text editor.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">file</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
       <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">findutils</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">fio</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">firefox</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/games">games</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Play games in Clear Linux.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/games-dev">games-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the games bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (games) bundle.</li>
@@ -490,25 +440,21 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">gimp</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">git</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/go-basic">go-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run go language programs.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/go-basic-dev">go-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the go-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (go-basic) bundle.</li>
@@ -520,19 +466,16 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">gzip</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/hardware-bluetooth">hardware-bluetooth</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Software to enable use of bluetooth hardware.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/haskell-basic">haskell-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run haskell language programs.
           <li>Includes (c-basic) bundle.</li>   
           <li>Includes (perl-basic) bundle.</li></p>
@@ -541,50 +484,42 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/hpc-utils">hpc-utils</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Provide userspace management programs for various HPC related programs.
           <li>Includes (perl-basic) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">htop</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">httpd</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">hugo</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">icdiff</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">inotify-tools</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">irssi</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java-basic">java-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run java language programs.
           <li>Includes (libX11client) bundle.</li>
           <li>Includes (python-basic) bundle.</li>
@@ -595,14 +530,12 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java-runtime">java-runtime</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run java language programs.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/java9-basic">java9-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run java9 language programs.
           <li>Includes (libX11client) bundle.</li>
           <li>Includes (python-basic) bundle.</li>                  
@@ -613,19 +546,16 @@
   
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">joe</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">jq</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-aws">kernel-aws</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the kvm specific kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -633,13 +563,11 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-container">kernel-container</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the container specific kernel.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-gce">kernel-gce</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the kvm specific kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -647,7 +575,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-hyperv">kernel-hyperv</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the hyperv specific kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -655,7 +582,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-hyperv-lts">kernel-hyperv-lts</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the hyperv specific LTS kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -663,7 +589,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-hyperv-mini">kernel-hyperv-mini</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the hyperv mini-os specific kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -671,14 +596,12 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-kvm">kernel-kvm</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the kvm specific kernel.
           <li>Includes (bootloader) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-lts">kernel-lts</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the lts native kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -686,7 +609,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-native">kernel-native</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the native kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -694,7 +616,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-oracle">kernel-oracle</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run the Oracle Cloud specific kernel.
           <li>Includes (bootloader) bundle.</li></p>
       </td>
@@ -702,14 +623,12 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kernel-pk">kernel-pk</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the Intel "PK" kernel, and enterprise-style kernel with backports.
           <li>Includes (bootloader) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/koji">koji</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Sets up a koji build service based on NFS mounts.
           <li>Includes (package-utils) bundle.</li>
           <li>Includes (python-basic) bundle.</li>
@@ -721,39 +640,33 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/kvm-host">kvm-host</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run virtual machines.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/letsencrypt-client">letsencrypt-client</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Obtain and renew valid SSL certificates through Let's Encrypt's ACME service.
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/libX11client">libX11client</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Grouping only bundle for use in X using bundles.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">linux-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">linux-tools</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/machine-learning-basic">machine-learning-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build machine learning applications.
           <li>Includes (c-basic) bundle.</li>
           <li>Includes (python) bundle.</li>
@@ -765,7 +678,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/machine-learning-web-ui">machine-learning-web-ui</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Web based, interactive tools for machine learning.
           <li>Includes (R-basic) bundle.</li> 
           <li>Includes (R-extras) bundle.</li>
@@ -777,14 +689,12 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/mail-utils">mail-utils</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Process, read and send email
           <li>Includes (python2-basic) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/mail-utils-dev">mail-utils-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the mail-utils bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (mail-utils) bundle.</li>
@@ -797,7 +707,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/mixer">mixer</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Create Clear Linux releases.
           <li>Includes (os-installer) bundle.</li>
           <li>Includes (python-basic) bundle.</li>          
@@ -809,21 +718,19 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">mkosi</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/network-basic">network-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run network utilities and modify network settings.
           <li>Includes (perl-basic) bundle.</li>
-          <li>Includes (python3-basic) bundle.</li></p></td>
+          <li>Includes (python3-basic) bundle.</li></p>
+      </td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/network-basic-dev">network-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the network-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (network-basic) bundle.</li>
@@ -836,51 +743,43 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">nginx</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/nodejs-basic">nodejs-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run javascript server side.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/openssh-server">openssh-server</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run an ssh server.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">openssl</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-clear-containers">os-clear-containers</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Control Clear Containers guest setup and workloads.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest">os-cloudguest</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run any initialization processes required of a generic cloud guest VM.
           <li>Includes (openssh-server) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-aws">os-cloudguest-aws</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required of an AWS cloud guest VM.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-azure">os-cloudguest-azure</a></td>
-      <td class="bundlestatus">Active</td>
-      <td class="bundledesc"><p>Run any initialization process requried of an Azure cloud guest VM.
+      <td class="bundledesc"><p>Run any initialization process required of an Azure cloud guest VM.
           <li>Includes (openssh-server) bundle.</li>
           <li>Includes (python-basic) bundle.</li>
           <li>Includes (python2-basic) bundle.</li>
@@ -890,26 +789,22 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-gce">os-cloudguest-gce</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required of an GCE cloud guest VM.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-cloudguest-oracle">os-cloudguest-oracle</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required of an Oracle Cloud guest.
           <li>Includes (openssh-server) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/os-cloudguest-vmware">os-cloudguest-vmware</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run any initialization processes required for VMWare VMs.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-clr-on-clr">os-clr-on-clr</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run any process required for Clear Linux development.
           <li>Includes (c-basic) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
@@ -946,7 +841,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-clr-on-clr-dev">os-clr-on-clr-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-clr-on-clr bundle.
           <li>Includes (c-basic) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
@@ -986,13 +880,11 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core">os-core</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a minimal Linux userspace.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core-dev">os-core-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-core bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (perl-basic) bundle.</li>          
@@ -1002,14 +894,12 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core-update">os-core-update</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides basic suite for running the Clear Linux for iA Updater.</p>
       </td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-core-update-dev">os-core-update-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-core-update bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
@@ -1022,20 +912,17 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-installer">os-installer</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run image creation and installation for Clear Linux.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-testsuite">os-testsuite</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides minimal functionality for core testing functions.
           <li>Includes (openssh-server) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-testsuite-phoronix">os-testsuite-phoronix</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run the Phoronix testsuite.
           <li>Includes (R-basic) bundle.</li>          
           <li>Includes (c-basic) bundle.</li>
@@ -1062,7 +949,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-utils-gui">os-utils-gui</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides a graphical desktop environment.
           <li>Includes (cryptography) bundle.</li>
           <li>Includes (libX11client) bundle.</li>          
@@ -1075,7 +961,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/os-utils-gui-dev">os-utils-gui-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the os-utils-gui bundle.
           <li>Includes (cryptography) bundle.</li>
           <li>Includes (dev-utils) bundle.</li>
@@ -1093,7 +978,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/package-utils">package-utils</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Utilities for creating, building, and managing packages.
           <li>Includes (python3-basic) bundle.</li></p>
       </td>
@@ -1101,19 +985,16 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">parallel</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">patch</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/performance-tools">performance-tools</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run performance and power measurements.
           <li>Includes (libX11client) bundle.</li>            
           <li>Includes (perl-basic) bundle.</li>
@@ -1124,13 +1005,11 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/perl-basic">perl-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run perl language programs.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/perl-basic-dev">perl-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the perl-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
@@ -1141,7 +1020,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/perl-extras">perl-extras</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Improve user experience with a common set of pre-built perl libraries.
           <li>Includes (perl-basic) bundle.</li></p>
       </td>
@@ -1149,37 +1027,31 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/php-basic">php-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run php language programs.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">pmdk</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/pnp-tools-basic">pnp-tools-basic</a></td>
-      <td class="bundlestatus">Deprecated</td>
       <td class="bundledesc"><p>Run performance and power measurements.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">postgresql</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">powertop</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>    
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/productivity">productivity</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>A set of console utilities for task management and communication.
           <li>Includes (mail-utils) bundle.</li>
           <li>Includes (python2-basic) bundle.</li>
@@ -1189,13 +1061,11 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/pxe-server">pxe-server</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a PXE server.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python-basic">python-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run python language programs.
           <li>Includes (python2-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p>
@@ -1204,7 +1074,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python-basic-dev">python-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the python-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
@@ -1218,7 +1087,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python-extras">python-extras</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Improve user experience with a common set of pre-built python libraries.
           <li>Includes (python-basic) bundle.</li>
           <li>Includes (python2-basic) bundle.</li>
@@ -1228,26 +1096,22 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python2-basic">python2-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run legacy python language programs.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/python3-basic">python3-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run python language programs.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/qt-basic">qt-basic</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run programs that use the QT runtime.
           <li>Includes (python3-basic) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/qt-basic-dev">qt-basic-dev</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>All packages required to build the qt-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
@@ -1259,45 +1123,38 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/ruby-basic">ruby-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run ruby language programs.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/rust-basic">rust-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Build and run rust language programs.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/scm-server">scm-server</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run a source code management server.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/service-os">service-os</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Provides the needed software for Service OS.
           <li>Includes (bootloader) bundle.</li></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/shells">shells</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a shell.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/bundles/software-defined-cockpit">software-defined-cockpit</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p> Run the automotive software defined cockpit which has graphic, media, sound and connectivity.</p>
       </td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/storage-cluster">storage-cluster</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a storage server.
           <li>Includes (python3-basic) bundle.</li>
           <li>Includes (python2-basic) bundle.</li></p>
@@ -1306,14 +1163,12 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/storage-utils">storage-utils</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run disk and file system management functions.</p>
       </td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/storage-utils-dev">storage-utils-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the storage-utils bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>
@@ -1325,37 +1180,31 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">strace</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/stream-server">stream-server</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run an audio or visual streaming server.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">subversion</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">suricata</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-basic">sysadmin-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run common utilities useful for managing a system.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-basic-dev">sysadmin-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the sysadmin-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (os-core-dev) bundle.</li>       
@@ -1367,7 +1216,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-hostmgmt">sysadmin-hostmgmt</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Utilities and Services for managing large-scale clusters of networked hosts.
           <li>Includes (pxe-server) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p></td>
@@ -1375,7 +1223,6 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/sysadmin-remote">sysadmin-remote</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Enable the host to be managed remotely by configuration management tools.
           <li>Includes (openssh-server) bundle.</li>
           <li>Includes (python-basic) bundle.</li>
@@ -1386,13 +1233,11 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">systemd-cryptsetup</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/tcl-basic">tcl-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run tk/tcl language programs.
           <li>Includes (libX11client) bundle.</li></p>
       </td>
@@ -1400,38 +1245,32 @@
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/telemetrics">telemetrics</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run telemetrics client.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">thunderbird</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/time-server-basic">time-server-basic</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Run an NTP server.</p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">tmux</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">unzip</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p>
     </td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/user-basic">user-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Meta bundle capturing most console user work flows.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (editors) bundle.</li>
@@ -1454,7 +1293,6 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/user-basic-dev">user-basic-dev</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>All packages required to build the user-basic bundle.
           <li>Includes (dev-utils) bundle.</li>
           <li>Includes (dev-utils-dev) bundle.</li>
@@ -1477,13 +1315,11 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">valgrind</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/vim">vim</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>The popular vim text editor
           <li>Includes (perl-basic) bundle.</li>
           <li>Includes (python3-basic) bundle.</li></p>
@@ -1492,13 +1328,11 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">vlc</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/vnc-server">vnc-server</a></td>
-      <td class="bundlestatus">WIP</td>
       <td class="bundledesc"><p>Enable the host to be a vnc desktop server.
           <li>Includes (desktop) bundle.</li>
           <li>Includes (desktop-apps) bundle.</li>          
@@ -1514,38 +1348,32 @@
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/web-server-basic">web-server-basic</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run a HTTP web server.</p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">weechat</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">wireshark</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/tree/master/bundles/xfce4-desktop">xfce4-desktop</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p>Run GUI desktop environment.
           <li>Includes (libX11client) bundle.</li></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">xz</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
     
     <tr>
       <td class="bundlename"><a href="https://github.com/clearlinux/clr-bundles/blob/master/packages">zsh</a></td>
-      <td class="bundlestatus">Active</td>
       <td class="bundledesc"><p></p></td>
     </tr>
 


### PR DESCRIPTION
- http://kojiclear.jf.intel.com/cgit/projects/bundle-tools¸ ./gendocs.sh
- script provided by matthew johnson, https://github.com/clearlinux/clear-linux-documentation/issues/126

Signed-off-by: Michael Vincerra <michaelx.vincerra@intel.com>