### PR TITLE
mixin: fix local-rpm documentation

### DIFF
--- a/source/clear-linux/guides/maintenance/mixin.rst
+++ b/source/clear-linux/guides/maintenance/mixin.rst
@@ -44,7 +44,7 @@ Set up the workspace
 
    .. code-block:: console
 
-      $ sudo mkdir -p /usr/share/mix/rpms
+      $ sudo mkdir -p /usr/share/mix/local-rpms
 
 Copy your custom RPM package to the workspace
 *********************************************
@@ -61,7 +61,7 @@ your RPM package to the workspace.
 
 .. code-block:: console
 
-   $ sudo cp [RPM] /usr/share/mix/rpms
+   $ sudo cp [RPM] /usr/share/mix/local-rpms
 
 Alternatively, you can add a remote RPM repository by running the following
 command.


### PR DESCRIPTION
The /usr/share/mix/rpms directory is no longer used by mixer/mixin.
Instead use the appropriate default /usr/share/mix/local-rpms directory
because this is where mixer looks for local RPMs when initializing the
local repository.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

This fixes a **bug** in the documentation.