### PR TITLE
mixin: add --bundle flag information

### DIFF
--- a/source/clear-linux/guides/maintenance/mixin.rst
+++ b/source/clear-linux/guides/maintenance/mixin.rst
@@ -78,13 +78,15 @@ package.
 
 .. code-block:: console
 
-   $ sudo mixin package add [package-name] [--build]
+   $ sudo mixin package add [package-name] [--bundle bundle-name] [--build]
 
 This command will add package-name to a bundle that is named after its parent
 repository. For example, if the RPM was provided locally, it will be added to
 the 'local' bundle. If it came from a repo that was added with :command:`mixin
-repo add` it will be added to a bundle named after the repo-name. The `--build`
-flag tells :command:`mixin` to run a `mixer` build after adding the package.
+repo add` it will be added to a bundle named after the repo-name. If the
+`--bundle bundle-name` flag is provided the package will be added to
+`bundle-name` instead. The `--build` flag tells :command:`mixin` to run a
+`mixer` build after adding the package.
 
 To add more than one RPM to your previously-created bundle, repeat
 the :command:`mixin package add` command and change the package name. Do not add


### PR DESCRIPTION
Add information for latest functionality of the mixin package
subcommand. The --bundle flag allows users to specify the name of the
bundle they add their package to.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>