### PR TITLE
swupd: fix autoupdate documentation

### DIFF
--- a/source/clear-linux/concepts/swupd-about.rst
+++ b/source/clear-linux/concepts/swupd-about.rst
@@ -95,11 +95,11 @@ patches.
 Clear Linux OS will automatically check for updates and apply them. This default
 can be disabled by running::
 
-    # systemctl mask swupd-update.timer
+    # swupd autoupdate --disable
 
 And reenabled by running::
 
-    # systemctl unmask swupd-update.timer
+    # swupd autoupdate --enable
 
 
 Update speed


### PR DESCRIPTION
The autoupdate subcommand has been around for a very long time now and
should be used instead of the systemctl masking commands.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>