### PR TITLE
Concepts syntax

### DIFF
--- a/source/clear-linux/concepts/mixer-about.rst
+++ b/source/clear-linux/concepts/mixer-about.rst
@@ -12,5 +12,3 @@ Related Concepts
 
 * :ref:`swupd-about`
 * :ref:`bundles-about`
-
-

--- a/source/clear-linux/concepts/mixer-about.rst
+++ b/source/clear-linux/concepts/mixer-about.rst
@@ -10,7 +10,7 @@ Mixing is a multi-step process that starts with installing the mixer bundle usin
 Related Concepts
 ================
 
-* :ref:`swupd_about`
-* :ref:`bundles_about`
+* :ref:`swupd-about`
+* :ref:`bundles-about`
 
 


### PR DESCRIPTION
Fixed some typos and removed trailing carriage returns. After a local build links are fixed in both concepts.rst and mixer-about.rst.