### PR TITLE
Add swupd search and help to bundle commands reference

### DIFF
--- a/source/clear-linux/reference/bundle-commands.rst
+++ b/source/clear-linux/reference/bundle-commands.rst
@@ -3,20 +3,51 @@
 Useful bundle commands
 ######################
 
-To see a list of currently-installed bundles, enter:
 
-.. code-block:: console
 
-   # swupd bundle-list
+To see a list of currently installed bundles, enter:
+
+    :command:`swupd` :option:`bundle-list`
+
 
 To see the list of all available bundles, enter:
 
-.. code-block:: console
+    :command:`swupd` :option:`bundle-list --all`
 
-   # swupd bundle-list --all
+
+    Alternatively, you may reference the `available bundle list`_ webpage.
+
+
+To search for bundles and their contents, enter:
+
+    .. code-block:: console
+
+        # swupd search [bundle name]
+
 
 To add a bundle, enter:
 
-.. code-block:: console
+    .. code-block:: console
 
-   # swupd bundle-add [bundle name]
+        # swupd bundle-add [bundle name]
+
+
+
+
+Additional information 
+======================
+
+For additional :command:`swupd` commands, enter:
+
+    .. code-block:: console
+
+        # swupd --help 
+
+or reference the :command:`swupd` man page, enter:
+
+    .. code-block:: console
+
+        # man swupd
+
+
+.. _available bundle list: https://clearlinux.org/documentation/clear-linux/reference/bundles/available-bundles#bundle-list


### PR DESCRIPTION
- Add command to search for bundles and reference to online bundle-list
- Add swupd help as additional information
- Reformat commands with switches but no parameters as commands instead of code-blocks