### PR TITLE
Fix minor syntax error blocking substitution

### DIFF
--- a/source/clear-linux/tutorials/docker/docker.rst
+++ b/source/clear-linux/tutorials/docker/docker.rst
@@ -4,7 +4,7 @@ Run Docker\* on Clear Linux\*
 #############################
 
 |CLOSIA| supports multiple containerization platforms, including a Docker\* 
-solution.|CL| has many `unique features`_ including a minimal default 
+solution. |CL| has many `unique features`_ including a minimal default 
 installation which makes it compelling to use as a host for container 
 workloads, management, and orchestration. 
 


### PR DESCRIPTION
No space after period was causing |CL| substitution not to expand