### PR TITLE
Fix for issue #163 - lack of uniformity for validating image integrity

### DIFF
--- a/source/clear-linux/guides/maintenance/download-verify-uncompress-linux.rst
+++ b/source/clear-linux/guides/maintenance/download-verify-uncompress-linux.rst
@@ -42,6 +42,9 @@ checksum, a warning is displayed with a message indicating the computed
 checksum does **not** match. Otherwise, the name of the image is printed on
 the screen followed by `OK`.
 
+For a more in-depth discussion of image verification including checking the
+certificate see :ref:`image-content-validation`.
+
 Uncompress the Clear Linux image
 ********************************
 

--- a/source/clear-linux/guides/maintenance/validate-signatures.rst
+++ b/source/clear-linux/guides/maintenance/validate-signatures.rst
@@ -1,7 +1,7 @@
 .. _validate-signatures:
 
-Validate signatures
-###################
+Validating signatures
+#####################
 
 |CLOSIA| offers a way to validate the content of an image or an update. All
 validation of content works by creating and signing a hash. A valid signature
@@ -9,8 +9,10 @@ creates a chain of trust. A broken chain of trust, seen as an invalid
 signature, means the content is not valid.
 
 This guide covers how to validate the contents of an image, which is a manual
-process, and describes the automatic process ``swupd`` performs internally to
+process and is the same process ``swupd`` performs internally to
 validate an update.
+
+.. _image-content-validation:
 
 Image content validation
 ========================

--- a/source/clear-linux/guides/maintenance/validate-signatures.rst
+++ b/source/clear-linux/guides/maintenance/validate-signatures.rst
@@ -1,6 +1,6 @@
 .. _validate-signatures:
 
-Validating signatures
+Validate signatures
 #####################
 
 |CLOSIA| offers a way to validate the content of an image or an update. All

--- a/source/clear-linux/guides/maintenance/validate-signatures.rst
+++ b/source/clear-linux/guides/maintenance/validate-signatures.rst
@@ -1,7 +1,7 @@
 .. _validate-signatures:
 
 Validate signatures
-#####################
+###################
 
 |CLOSIA| offers a way to validate the content of an image or an update. All
 validation of content works by creating and signing a hash. A valid signature


### PR DESCRIPTION
Most users will not need to check the certificate, but it is worth having a link to the certificate and the method for checking it should the user wish to do so. 

Details: Added a reference to validate-signatures.rst to download-verify-uncompress-linux.rst for uniformity (issue 163). Made a couple wording changes to validate-signatures.rst and added a label to help with navigation.