### PR TITLE
Adds nginx web-server to show how to host mixer updates.

### DIFF
--- a/source/clear-linux/guides/maintenance/mixer.rst
+++ b/source/clear-linux/guides/maintenance/mixer.rst
@@ -70,13 +70,13 @@ server, where you can host custom |CL| mixes.
 
       sudo ln -sf $HOME/mixer/update/www /var/www/mixer
 
-#. To assure ``nginx`` starts by default, add and configure it. 
+#. Set up ``nginx`` configuration. 
 
    .. code-block:: bash
 
       sudo mkdir -p  /etc/nginx/conf.d
 
-#. Copy the default example configuration file to `/etc` to load on boot. 
+#. Copy the default example configuration file. 
 
    .. code-block:: bash
 


### PR DESCRIPTION
- Simplifies and combines two mix workflows at start
- Fixes Sphinx syntax
- Replaces incorrect link to web server in section CONTENTURL, VERSIONURL

Signed-off-by: Michael Vincerra <michaelx.vincerra@intel.com>