### PR TITLE
kata: add link to kata_migrate

### DIFF
--- a/source/clear-linux/tutorials/kata.rst
+++ b/source/clear-linux/tutorials/kata.rst
@@ -16,6 +16,8 @@ This tutorial assumes you have installed |CL| on your host system.
 For detailed instructions on installing |CL| on a bare metal system, visit
 the :ref:`bare metal installation tutorial<bare-metal-install>`.
 
+If you have Clear Containers installed on your |CL| system, then follow the :ref:`Migrate Clear Containers to Kata Containers\* tutorial<kata_migration>`.
+
 Before you install any new packages, update |CL| with the following command:
 
 .. code-block:: bash


### PR DESCRIPTION
Users that already have Clear Containers installed on their
system should follow the migration guide.
This commit adds an explanatory note and a link to the
Clear Containers to Kata Containers migration guide.

Signed-off-by: Jose Lamego <jose.a.lamego@intel.com>