### PR TITLE
Removes instances of s/cc-runtime for kata per @devimc

### DIFF
--- a/source/clear-linux/tutorials/kata.rst
+++ b/source/clear-linux/tutorials/kata.rst
@@ -87,11 +87,11 @@ More information about Docker in |CLOSIA|.
 #############################################
 
 Docker on |CLOSIA| provides a docker.service service file to start the Docker
-daemon. The daemon will use runc or s/cc-runtime/kata-runtime depending on 
+daemon. The daemon will use runc or kata-runtime depending on 
 the environment:
 
 If you are running |CL| on bare metal or on a VM with Nested
-Virtualization activated, Docker will use s/cc-runtime/kata-runtime as the
+Virtualization activated, Docker will use kata-runtime as the
 default runtime. If you are running |CL| on a VM without Nested
 Virtualization, Docker will use runc as the default runtime. It is not
 necessary to manually configure the runtime for Docker, since Docker itself


### PR DESCRIPTION
Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>