### PR TITLE
Appends ':' to the end of the target-label

### DIFF
--- a/source/clear-linux/concepts/autospec-about.rst
+++ b/source/clear-linux/concepts/autospec-about.rst
@@ -3,7 +3,7 @@
 Autospec
 ########
 
-.. _incl-autospec-overview
+.. _incl-autospec-overview:
 
 Overview
 --------

--- a/source/clear-linux/guides/maintenance/autospec.rst
+++ b/source/clear-linux/guides/maintenance/autospec.rst
@@ -68,8 +68,8 @@ Create a RPM with autospec
 **************************
 
 .. include:: ../../concepts/autospec-about.rst
-   :Start-after: incl-autospec-overview
-   :end-before: incl-autospec-overview-end
+   :Start-after: incl-autospec-overview:
+   :end-before: incl-autospec-overview-end:
 
 For a detailed explanation of how ``autospec`` works on |CL|, visit our 
 :ref:`autospec-about` about page.  For a general understanding of how RPMs 


### PR DESCRIPTION
- where it appears in autospec-about
- where it is used in the "include"

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>