### PR TITLE
Fixed last of the warnings in the Sphinx Build

### DIFF
--- a/source/clear-linux/concepts/restart.rst
+++ b/source/clear-linux/concepts/restart.rst
@@ -6,7 +6,8 @@ Restart system services after an OS update
 The software life cycle describes how software is created, developed, and
 deployed, and includes how to replace or update software. A good OS
 provides tools for the entire software life cycle. These tools must include
-ways to remove software components properly when replaced with something else.
+ways to remove software components properly when replaced with something
+else.
 
 Most of the work on software update code in |CL| was focused on adding new
 software to the system. We recommended that users reboot their system once in
@@ -32,9 +33,9 @@ solutions such as the following:
   * Ask the user to restart the OS.
 
 Both solutions are acceptable for many OSes. However, |CL| updates software
-automatically and users do not see notices from the updater unless they review
-the journal. |CL| requires a completely different solution, with the following
-requirements:
+automatically and users do not see notices from the updater unless they
+review the journal. |CL| requires a completely different solution, with the
+following requirements:
 
 * Eliminate the guesswork about what to restart and under what circumstances.
 * Cannot restart everything. Many service daemons do not support an automatic
@@ -105,17 +106,19 @@ The *disallow* option tells :command:`clr-service-restart` not to
 restart the specified daemon even if the OS defaults permit the daemon to be
 restarted. The :command:`clr-service-restart` daemon creates a symlink in
 :file:`/etc/clr-service-restart` that points to :file:`/dev/null` as a
-record. The example below tells :command:`clr-service-restart` not to restart the *rngd* daemon after an OS software update.
+record. The example below tells :command:`clr-service-restart` not to
+restart the *rngd* daemon after an OS software update.
 
 .. code-block:: bash
 
    sudo clr-service-restart disallow rngd
 
 The *default* option makes :command:`clr-service-restart` revert back
-to the OS defaults and delete any symlink in :file:`/etc/clr-service-restart`.
-The example below tells :command:`clr-service-restart` to restart
-*rngd* automatically again, because *rngd* is whitelisted for
-automatic service restarts by default in |CL|.
+to the OS defaults and delete any symlink 
+in :file:`/etc/clr-service-restart`. The example below 
+tells :command:`clr-service-restart` to restart *rngd* automatically again,
+because *rngd* is whitelisted for automatic service restarts by default
+in |CL|.
 
 .. code-block:: bash
 
@@ -166,12 +169,14 @@ telemetry record and sends it to the optional |CL| telemetry service if both
 conditions below are met:
 
 * If a unit fails to automatically restart after an OS update.
-* If that unit resides in the system location :file:`/usr/lib/systemd/system`.
+* If that unit resides in the system 
+  location :file:`/usr/lib/systemd/system`.
 
 If you do not install the |CL| telemetrics bundle, the data is discarded. If
 you install the telemetrics bundle and you opt to send telemetry, then the
-system unit name is sent to the |CL| telemetry service. We evaluate the report
-and update the whitelist to remove services that are not safe to restart.
+system unit name is sent to the |CL| telemetry service. We evaluate the
+report and update the whitelist to remove services that are not safe to
+restart.
 
 Conclusion
 **********

--- a/source/clear-linux/concepts/restart.rst
+++ b/source/clear-linux/concepts/restart.rst
@@ -81,7 +81,7 @@ Figure 1: Invoke :command:`clr-service-restart`.
 
 :command:`clr-service-restart` implements a whitelist to identify which
 daemons can be restarted. The system administrator can customize the default
-|CL| OS whitelist using :option:`allow` or :option:`disallow` options for
+|CL| OS whitelist using *allow* or *disallow* options for
 restarting system services. When a software update occurs,
 :command:`clr-service-restart` consults the whitelist to see if a service
 daemon is allowed to be restarted or not. See the options section for
@@ -91,31 +91,30 @@ details.
 Options for clr-service-restart
 *******************************
 
-The :option:`allow` option identifies a daemon to restart after an OS software
+The *allow* option identifies a daemon to restart after an OS software
 update. The :command:`clr-service-restart` daemon creates a symlink in
 :file:`/etc/clr-service-restart` as a record. The example below tells
-:command:`clr-service-restart` to restart the :option:`tallow` daemon after an
+:command:`clr-service-restart` to restart the *tallow* daemon after an
 OS software update.
 
 .. code-block:: bash
 
    sudo clr-service-restart allow tallow.service
 
-The :option:`disallow` option tells :command:`clr-service-restart` not to
+The *disallow* option tells :command:`clr-service-restart` not to
 restart the specified daemon even if the OS defaults permit the daemon to be
 restarted. The :command:`clr-service-restart` daemon creates a symlink in
-:file:`/etc/clr-service-restart` that points to :file:`/dev/null` as a record.
-The example below tells :command:`clr-service-restart` not to restart the
-:option:`rngd` daemon after an OS software update.
+:file:`/etc/clr-service-restart` that points to :file:`/dev/null` as a
+record. The example below tells :command:`clr-service-restart` not to restart the *rngd* daemon after an OS software update.
 
 .. code-block:: bash
 
    sudo clr-service-restart disallow rngd
 
-The :option:`default` option makes :command:`clr-service-restart` revert back
+The *default* option makes :command:`clr-service-restart` revert back
 to the OS defaults and delete any symlink in :file:`/etc/clr-service-restart`.
 The example below tells :command:`clr-service-restart` to restart
-:option:`rngd` automatically again, because :option:`rngd` is whitelisted for
+*rngd* automatically again, because *rngd* is whitelisted for
 automatic service restarts by default in |CL|.
 
 .. code-block:: bash
@@ -132,23 +131,24 @@ services are restarted after an OS software update.
 To monitor :command:`clr-service-restart`, use one or both options described
 below.
 
-:option:`-n`
+.. option:: -n
 
-This option makes :command:`clr-service-restart` perform no restarts. Instead
-it displays the services that could potentially be restarted. When used,
-:command:`clr-service-restart` outputs a list of messages showing:
+   This option makes :command:`clr-service-restart` perform no restarts.
+   Instead it displays the services that could potentially be restarted.
+   When used, :command:`clr-service-restart` outputs a list of messages
+   showing:
 
-* Which service needs a restart.
-* What unit it is.
-* Why it needs a restart.
-* Which command is required to restart the unit.
+   * Which service needs a restart.
+   * What unit it is.
+   * Why it needs a restart.
+   * Which command is required to restart the unit.
 
-:option:`-a`
+.. option:: -a
 
-This option makes :command:`clr-service-restart` consider all system services,
-not only the ones that are whitelisted. Because the default whitelist in |CL|
-is relatively short, you can use this option to restart all impacted services
-when you log in on the system.
+   This option makes :command:`clr-service-restart` consider all system
+   services, not only the ones that are whitelisted. Because the default
+   whitelist in |CL| is relatively short, you can use this option to
+   restart all impacted services when you log in on the system.
 
 If you pass both options (:option:`-a` and :option:`-n`),
 :command:`clr-service-restart` displays a complete list of system services

--- a/source/clear-linux/concepts/swupd-about.rst
+++ b/source/clear-linux/concepts/swupd-about.rst
@@ -129,7 +129,7 @@ system and its updates as the basis. Using this tool, system administrators
 can focus on the custom pieces their deployments require while staying on
 a controlled update stream.
 
-To learn how to run an update of your system, visit our :ref:`update` page.
+To learn how to run an update of your system, visit our :ref:`using swupd <swupd-guide>` page.
 
 .. [1] The software update technology for Clear Linux* OS for Intel
    Architecture was first presented at the Linux Plumbers conference in 2012.

--- a/source/clear-linux/guides/maintenance/bulk-provision.rst
+++ b/source/clear-linux/guides/maintenance/bulk-provision.rst
@@ -92,7 +92,7 @@ Configuration
    within the web hosting directory of **ICIS**. The following example shows
    an Ister configuration file:
 
-   .. code-block:: json
+   .. code-block:: none
 
       template=http://192.168.1.1:60000/icis/static/ister/ister.json
 
@@ -102,7 +102,7 @@ Configuration
    kernel parameter value.  The following example shows an iPXE boot script
    with the ``isterconf`` parameter:
 
-   .. code-block:: json
+   .. code-block:: none
 
       #!ipxe
       kernel linux quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp rw initrd=initrd isterconf=http://192.168.1.1:60000/icis/static/ister/ister.conf
@@ -129,7 +129,7 @@ Configuration
    in the ``static`` directory within the web hosting directory of **ICIS**.
    The following example shows one such assignment:
 
-   .. code-block:: json
+   .. code-block:: none
 
       # MAC address,role
       00:01:02:03:04:05,ciao
@@ -138,7 +138,7 @@ Configuration
    :file:`config.txt` file, a default role for those MAC address may be
    defined as follows:
 
-   .. code-block:: json
+   .. code-block:: none
 
       # MAC address,role
       default,ciao

--- a/source/clear-linux/guides/maintenance/mixer.rst
+++ b/source/clear-linux/guides/maintenance/mixer.rst
@@ -190,7 +190,7 @@ For example:
 
 
 Additionally, to build a mix with your own custom RPMs, use the optional
-:option:`--local-rpms` flag, for example:
+*--local-rpms* flag, for example:
 
 .. code-block:: bash
 
@@ -203,7 +203,7 @@ the paths manually. For more information on using these directories or
 setting them up manually, see `Create or locate RPMs for the mix`_.
 
 If all upstream |CL| bundles will be part of the mix, you can easily add 
-them all during initialization with the optional :option:`--all-upstream` flag. For example:
+them all during initialization with the optional *--all-upstream* flag. For example:
 
 .. code-block:: bash
 
@@ -212,7 +212,7 @@ them all during initialization with the optional :option:`--all-upstream` flag. 
 Finally, you may want to track the contents of your mixer workspace with a
 git repository. This is a great way to track changes to your mix's content
 or to revert to earlier versions if something goes wrong. Mixer can set this
-up automatically with the optional :option:`--git` flag, for example:
+up automatically with the optional *--git* flag, for example:
 
 .. code-block:: bash
 
@@ -231,7 +231,7 @@ Edit builder.conf
 To configure the mixer tool, edit the :file:`builder.conf` as needed.
 
 The file :file:`builder.conf` is read automatically from the current
-workspace directory. Use the :option:`--config` flag during initialization
+workspace directory. Use the *--config* flag during initialization
 to specify an alternate path to the file as needed.
 
 The :file:`builder.conf` file has different sections, for example:
@@ -417,7 +417,7 @@ bundles. When listing bundles with this command, mixer automatically
 recurses through the includes to show every single bundle in the mix.
 
 If you see an unexpected bundle in the list, that bundle is probably included
-in another bundle. Use the :option:`--tree` flag to get a better view of how
+in another bundle. Use the *--tree* flag to get a better view of how
 a bundle ended up in the mix, for example:
 
 .. code-block:: bash
@@ -459,7 +459,7 @@ with the following command:
    mixer bundle list local
 
 Both the local and upstream :command:`bundle list` commands accept the
-:option:`--tree` flag to show a visual representation of the inclusion relationships
+*--tree* flag to show a visual representation of the inclusion relationships
 between the bundles in the mix.
 
 Edit the bundles in the mix
@@ -561,7 +561,7 @@ This command removes `bundle1` from the mix bundle list stored in your
 :file:`mixbundles` file. By default, this command does not remove the bundle
 definition file from your local bundles. To completely remove a bundle,
 including its local bundle definition file, use the following command with
-the :option:`--local` flag:
+the *--local* flag:
 
 .. code-block:: bash
 
@@ -569,7 +569,7 @@ the :option:`--local` flag:
 
 By default, removing a local bundle file with this command removes the bundle
 from the mix as well. To only remove the local bundle definition file, use
-the following command with the :option:`--mix=false` flag:
+the following command with the *--mix=false* flag:
 
 .. code-block:: bash
 
@@ -599,7 +599,7 @@ can run this validation manually on `bundle1` with the following command:
 .. note:: This command can be useful in many circumstances. One example is
    when importing already-existing local bundles from other projects.
 
-If you use the optional :option:`--strict` flag, the command additionally
+If you use the optional *--strict* flag, the command additionally
 checks if the rest of the bundle header fields can be parsed, if the bundle
 header fields are non-empty, and if the bundle header ``Title`` field and
 the bundle filename match. Perform a strict validation of `bundle1` with the
@@ -624,7 +624,7 @@ git commit after you modify the mix bundle list or edit a bundle definition
 file.
 
 All the :command:`mixer bundle` commands in the previous sections support an
-optional :option:`--git` flag. This flag automatically applies a git commit
+optional *--git* flag. This flag automatically applies a git commit
 when the command completes, for example:
 
 .. code-block:: bash
@@ -654,7 +654,7 @@ chroots.
 We have added a new chroot-builder to the mixer tool itself. While this is
 currently an experimental feature, you should use the new chroot-builder. To
 use the new chroot-builder, use the following command with the
-:option:`--new-chroots` flag:
+*--new-chroots* flag:
 
 .. code-block:: bash
 
@@ -681,7 +681,7 @@ By default, mixer uses the legacy `swupd-server` to generate the update
 content. However, we have built a new implementation into the mixer tool
 itself. While this is currently an experimental feature, you should use the
 new `swupd-server`. To use the the new `swupd-server`, use the following
-command with the :option:`--new-swupd` flag:
+command with the *--new-swupd* flag:
 
 .. code-block:: bash
 
@@ -704,7 +704,7 @@ mix version to another, with the following command:
 
 The pack-maker generates all delta packs for the bundles changed from
 `PAST_VERSION` to `MIX_VERSION`. If your `STATE_DIR` is in a different
-location, specify the location with the :option:`-S` flag. Mixer cannot
+location, specify the location with the *-S* flag. Mixer cannot
 create delta packs for the first build because the update is from version 0.
 Version 0 implicitly has no content. Thus, mixer can generate no deltas.
 
@@ -754,7 +754,7 @@ With the `ister` tool configured, build the image with the following command:
 
 Mixer automatically looks for the :file:`release-image-config.json` file, but
 you can freely choose the filename. To use a different name, simply pass the
-:option:`--template` flag when creating your image, for example:
+*--template* flag when creating your image, for example:
 
 .. code-block:: bash
 
@@ -762,7 +762,7 @@ you can freely choose the filename. To use a different name, simply pass the
 
 By default, `ister` uses the format version of the build machine it runs on.
 Therefore, if the format you are building differs from the format of the |CL|
-OS you are building on, you must use the :option:`--format <FORMAT_NUMBER>`
+OS you are building on, you must use the *--format <FORMAT_NUMBER>*
 flag. Find the current format version of your OS with the following command:
 
 .. code-block:: bash
@@ -780,14 +780,14 @@ Increment the mix version number for the next mix with the following command:
 
 This command automatically updates the mix version stored in the
 :file:`mixversion` file, incrementing it by 10. To increment by a different
-amount, use the :option:`--increment` flag, for example:
+amount, use the *--increment* flag, for example:
 
 .. code-block:: bash
 
    mixer versions update --increment 100
 
 Alternatively, to set the mix version to a specific value, use the
-:option:`--mix-version` flag, for example:
+*--mix-version* flag, for example:
 
 .. code-block:: bash
 
@@ -802,7 +802,7 @@ If you have been tracking your workspace with git, you can restore the mix to
 an earlier state. However, be careful when "rewriting history" if you have
 published the mix content to users already.
 
-Use the following command with the the :option:`--upstream-version` flag to
+Use the following command with the the *--upstream-version* flag to
 update the upstream version of |CL| used as a base for the mix:
 
 .. code-block:: bash

--- a/source/clear-linux/guides/maintenance/swupd-guide.rst
+++ b/source/clear-linux/guides/maintenance/swupd-guide.rst
@@ -7,7 +7,7 @@ Use swupd
 valid system updates and, if found, download and install them. It can also
 perform verification of the system software. 
 
-|CL| uses :ref:`bundles-about<bundles>` as the base abstraction for
+|CL| uses :ref:`bundles <bundles-about>` as the base abstraction for
 installing functionality on top of the core operating system. Use the `swupd`
 tool to install and remove bundles.
 

--- a/source/clear-linux/reference/collaboration/documentation/documentation.rst
+++ b/source/clear-linux/reference/collaboration/documentation/documentation.rst
@@ -73,8 +73,7 @@ This style guide applies to the following technical content:
 
 We are always grateful to receive content contributions and are happy to help
 via our mailing list or our IRC channel, #clearlinux. If you have found a
-problem with one of our documents, please file a bug report. Use our
-:ref:`bug-report` to submit the bug.
+problem with one of our documents, please file a `bug report`_.
 
 Tone and audience
 *****************
@@ -86,12 +85,12 @@ Remain professional in your writing and carry an undertone of cordiality,
 respect, and cooperation.
 
 Assume your audience has about the same level of technical understanding and
-expertise as you did when you first started collaborating. Do not talk down to
-our readers but do not assume they know everything about the subject.
+expertise as you did when you first started collaborating. Do not talk down
+to our readers but do not assume they know everything about the subject.
 Offer brief explanations or summaries of "common knowledge" if a
 significant portion of readers might benefit.
 
-All contributions must follow our :ref:`code-of-conduct`.
+All contributions must follow our `code of conduct`_.
 
 Methodology
 ***********
@@ -126,7 +125,7 @@ decisions are explained in the respective section.
 
 This guide takes precedence over all other style guides in all cases. In
 cases where the guide does not address the issue at hand, please report the
-issue to the `mailing list`_ using our :ref:`bug-report`.
+issue to the `mailing list`_ using our `bug report`_.
 
 Use the Merriam-Webster's Collegiate Dictionary to determine correct
 spelling, hyphenation, and usage.
@@ -136,3 +135,5 @@ spelling, hyphenation, and usage.
 .. _documentation section: https://clearlinux.org/documentation
 .. _Clear Linux documentation repository:
    https://github.com/clearlinux/clear-linux-documentation
+.. _bug report: https://github.com/clearlinux/distribution/issues
+.. _code of conduct: https://clearlinux.org/community/code-of-conduct

--- a/source/clear-linux/reference/collaboration/documentation/inline.rst
+++ b/source/clear-linux/reference/collaboration/documentation/inline.rst
@@ -18,56 +18,62 @@ the roles.
   acronym can be used without further definition or markup. Do not use
   abbreviation markup on headings.
 
-   :abbr:`API (Application Program Interface)`
+     :abbr:`API (Application Program Interface)`
 
-   Template:
+  Template:
 
-   ``:abbr:`TIA (This Is an Abbreviation)```
+     ``:abbr:`TIA (This Is an Abbreviation)```
 
 * Use the `:command:` role when the name of a specific command is used in a
   paragraph for emphasis. Use the ``.. code-block::`` directive for fully
   actionable commands in a series of steps.
 
-   :command:`make`
+     :command:`make`
 
-   Template:
+  Template:
 
-   ``:command:`command```
+     ``:command:`command```
 
 * In most cases, use asterisks "*" to emphasize the name of a command
   option. However, if you have defined an ``.. option::`` directive, you may
   use the `:option:` role. For example:
 
-   Pandoc Options:
+     Pandoc Options:
 
-   .. option:: -f
-   .. option:: --all
-   .. option:: -o <output.xsl>
+     .. option:: -f
+     .. option:: --all
+     .. option:: -o <output.xsl>
 
-   The :command:`pandoc` command can be used without the :option:`-o`
-   option, creating an output file with the same name as the source
-   but a different extension.
+     The :command:`pandoc` command can be used without the :option:`-o`
+     option, creating an output file with the same name as the source
+     but a different extension.
 
-   Template:
+  Template:
    
-   .. code-block:: rest
+  .. code-block:: rest
 
       .. option: option
 
          description of option 
 
-   ``:option:`option```
+      :option:`option`
 
 * Use the `:file:` role to emphasize a filename or directory. Do not use the
   role inside a code-block but use it inside all notices that contain files
   or directories. Place variable parts of the path or filename in brackets
   `{}`.
 
-   :file:`collaboration.rst` :file:`doc/{user}/collaboration/figures`
+     :file:`collaboration.rst`
 
-   Template:
+     :file:`doc/{user}/collaboration/figures`
 
-   ``:file:`filename.ext` :file:`path/or/directory```
+  Template:
+
+     .. code-block:: rest
+
+        :file:`filename.ext` 
+
+        :file:`path/or/directory`
 
 * Use the `:guilabel:` role to emphasize elements of a graphic
   user interface within a description. It replaces the use of quotes
@@ -75,14 +81,16 @@ the roles.
   menu elements. Always follow the marked element with the appropriate
   noun. For example:
 
-   In the :guilabel:`Tools` menu.
-   Press the :guilabel:`OK` button.
-   In the :guilabel:`Settings` window you find the :guilabel:`Hide
-   Content` option.
+     In the :guilabel:`Tools` menu.
 
-   Template:
+     Press the :guilabel:`OK` button.
 
-   ``:guilabel:`UI-Label```
+     In the :guilabel:`Settings` window you find
+     the :guilabel:`Hide Content` option.
+
+  Template:
+
+     ``:guilabel:`UI-Label```
 
 * Use the `:menuselection:` role to indicate the navigation through a menu
   ending with a selection. Every `:menuselection:` element can have up to two
@@ -90,37 +98,41 @@ the roles.
   it can be combined with a `:guilabel:` or with another `:menuselection:`
   element. For example:
 
-   :menuselection:`File --> Save As --> PDF`
-   Go to :guilabel:`File` and select :menuselection:`Import --> Data
-   Base --> MySQL`.
-   Go to :menuselection:`Window --> View` and select :menuselection:`
-   Perspective --> Other --> C++`
+     :menuselection:`File --> Save As --> PDF`
 
-   Template:
+     Go to :guilabel:`File` and select :menuselection:`Import --> Data
+     Base --> MySQL`.
+  
+     Go to :menuselection:`Window --> View` and 
+     select :menuselection:`Perspective --> Other --> C++`
 
-   ``:menuselection:`1stMenu --> 2ndMenu --> Selection```
+  Template:
+
+     ``:menuselection:`1stMenu --> 2ndMenu --> Selection```
 
 * Use the `:makevar:` role to emphasize the name of a Makefile variable.
   The role can include only the name of the variable or the variable
   plus its value.
 
-   :makevar:`PLATFORM_CONFIG`
-   :makevar:`PLATFORM_CONFIG=basic_atom`
+     :makevar:`PLATFORM_CONFIG`
 
-   Template:
+     :makevar:`PLATFORM_CONFIG=basic_atom`
 
-   ``:makevar:`VARIABLE```
+  Template:
+
+     ``:makevar:`VARIABLE```
 
 * Use the `:envvar:` role to emphasize the name of environment
   variables. Just as with `:makevar:`, the markup can include only the
   name of the variable or the variable plus its value.
 
-   :envvar:`ZEPHYR_BASE`
-   :envvar:`QEMU_BIN_PATH=/usr/local/bin`
+     :envvar:`ZEPHYR_BASE`
+   
+     :envvar:`QEMU_BIN_PATH=/usr/local/bin`
 
-   Template:
+  Template:
 
-   ``:envvar:`ENVIRONMENT_VARIABLE```
+     ``:envvar:`ENVIRONMENT_VARIABLE```
 
 .. _Sphinx Inline Markup:
    http://sphinx-doc.org/markup/inline.html#inline-markup

--- a/source/clear-linux/reference/collaboration/documentation/inline.rst
+++ b/source/clear-linux/reference/collaboration/documentation/inline.rst
@@ -35,7 +35,8 @@ the roles.
    ``:command:`command```
 
 * In most cases, use asterisks "*" to emphasize the name of a command
-  option. However, if you have defined an ``.. option::`` directive, you may use the `:option:` role. For example:
+  option. However, if you have defined an ``.. option::`` directive, you may
+  use the `:option:` role. For example:
 
    Pandoc Options:
 

--- a/source/clear-linux/reference/collaboration/documentation/inline.rst
+++ b/source/clear-linux/reference/collaboration/documentation/inline.rst
@@ -6,133 +6,157 @@ Inline Markup
 Sphinx supports a large number of inline markup elements called roles. The
 |CLOSIA| documentation encourages the use of as many roles as
 possible. Thus, you can use any additional roles supported by Sphinx
-even if not listed here. Please refer to the `Sphinx Inline Markup`_
+not listed here. Please refer to the `Sphinx Inline Markup`_
 documentation for the full list of supported roles.
 
 The following markup is required in every instance unless otherwise
-specified. Each item provides examples and a template for the correct use of
-the roles.
+specified. Each item provides a syntax example followed by the rendered
+result.
 
-* Use the `:abbr:` abbreviation role to define an acronym or an initialism.
+Abbreviations
+  Use the `:abbr:` abbreviation role to define an acronym or an initialism.
   Add the abbreviation markup only once per file. After the abbreviation, the
   acronym can be used without further definition or markup. Do not use
   abbreviation markup on headings.
 
+  ::
+
      :abbr:`API (Application Program Interface)`
 
-  Template:
+  .. parsed-literal::
 
-     ``:abbr:`TIA (This Is an Abbreviation)```
+     :abbr:`API (Application Program Interface)`
 
-* Use the `:command:` role when the name of a specific command is used in a
+OS Commands
+  Use the `:command:` role when the name of a specific command is used in a
   paragraph for emphasis. Use the ``.. code-block::`` directive for fully
   actionable commands in a series of steps.
 
+  ::
+
      :command:`make`
 
-  Template:
+  .. parsed-literal::
 
-     ``:command:`command```
+     :command:`make`
 
-* In most cases, use asterisks "*" to emphasize the name of a command
-  option. However, if you have defined an ``.. option::`` directive, you may
-  use the `:option:` role. For example:
+Commandline Options
+  In most cases, use asterisks "*" to emphasize the name of a command
+  option. 
 
-     Pandoc Options:
+  ::
 
-     .. option:: -f
-     .. option:: --all
-     .. option:: -o <output.xsl>
+     Use the *-p* option to print the file.
 
-     The :command:`pandoc` command can be used without the :option:`-o`
-     option, creating an output file with the same name as the source
-     but a different extension.
+  .. parsed-literal::
 
-  Template:
-   
+     Use the *-p* option to print the file.
+
+  However, if you have defined an ``.. option::`` directive, you may
+  use the `:option:` role. Note that the result links back to the 
+  option definition.
+
   .. code-block:: rest
 
-      .. option: option
+     .. option: -o <output.xsl>
 
-         description of option 
+        Description of the -o option 
 
-      :option:`option`
+     The :command:`pandoc` command can be used without :option:`-o`
 
-* Use the `:file:` role to emphasize a filename or directory. Do not use the
+  .. option:: -o <output.xsl>
+
+     Description of the -o option
+
+  .. parsed-literal::
+
+     The :command:`pandoc` command can be used without :option:`-o` 
+
+Files
+  Use the `:file:` role to emphasize a filename or directory. Do not use the
   role inside a code-block but use it inside all notices that contain files
   or directories. Place variable parts of the path or filename in brackets
   `{}`.
+
+  .. code-block:: rest
 
      :file:`collaboration.rst`
 
      :file:`doc/{user}/collaboration/figures`
 
-  Template:
+  .. parsed-literal::
 
-     .. code-block:: rest
+     :file:`collaboration.rst`
 
-        :file:`filename.ext` 
+     :file:`doc/{user}/collaboration/figures`
 
-        :file:`path/or/directory`
-
-* Use the `:guilabel:` role to emphasize elements of a graphic
+GUI Objects
+  Use the `:guilabel:` role to emphasize elements of a graphic
   user interface within a description. It replaces the use of quotes
   when referring to windows' names, button labels, options, or single
   menu elements. Always follow the marked element with the appropriate
   noun. For example:
 
-     In the :guilabel:`Tools` menu.
+  ::
 
-     Press the :guilabel:`OK` button.
+     In the :guilabel:`Tools` menu, click :guilabel:`settings`.
 
-     In the :guilabel:`Settings` window you find
-     the :guilabel:`Hide Content` option.
+  .. parsed-literal::
 
-  Template:
+     In the :guilabel:`Tools` menu, click :guilabel:`settings`.
 
-     ``:guilabel:`UI-Label```
-
-* Use the `:menuselection:` role to indicate the navigation through a menu
+Menu Navigation
+  Use the `:menuselection:` role to indicate the navigation through a menu
   ending with a selection. Every `:menuselection:` element can have up to two
   menu steps before the selected item. If more than two steps are required,
   it can be combined with a `:guilabel:` or with another `:menuselection:`
   element. For example:
 
-     :menuselection:`File --> Save As --> PDF`
+  ::
 
-     Go to :guilabel:`File` and select :menuselection:`Import --> Data
-     Base --> MySQL`.
+     Go to :guilabel:`File` and select :menuselection:`Import --> Data Base --> MySQL`.
+
+     Go to :menuselection:`Window --> View` and select :menuselection:`Perspective --> Other --> C++`
+
+  .. parsed-literal::
+
+     Go to :guilabel:`File` and select :menuselection:`Import --> Data Base --> MySQL`.
   
-     Go to :menuselection:`Window --> View` and 
-     select :menuselection:`Perspective --> Other --> C++`
+     Go to :menuselection:`Window --> View` and select :menuselection:`Perspective --> Other --> C++`
 
-  Template:
-
-     ``:menuselection:`1stMenu --> 2ndMenu --> Selection```
-
-* Use the `:makevar:` role to emphasize the name of a Makefile variable.
+Makefile Variables
+  Use the `:makevar:` role to emphasize the name of a Makefile variable.
   The role can include only the name of the variable or the variable
   plus its value.
+
+  ::
 
      :makevar:`PLATFORM_CONFIG`
 
      :makevar:`PLATFORM_CONFIG=basic_atom`
 
-  Template:
+  .. parsed-literal::
 
-     ``:makevar:`VARIABLE```
+     :makevar:`PLATFORM_CONFIG`
 
-* Use the `:envvar:` role to emphasize the name of environment
+     :makevar:`PLATFORM_CONFIG=basic_atom`
+
+Environment Variables
+  Use the `:envvar:` role to emphasize the name of environment
   variables. Just as with `:makevar:`, the markup can include only the
   name of the variable or the variable plus its value.
+
+  ::
 
      :envvar:`ZEPHYR_BASE`
    
      :envvar:`QEMU_BIN_PATH=/usr/local/bin`
 
-  Template:
+  .. parsed-literal::
 
-     ``:envvar:`ENVIRONMENT_VARIABLE```
+     :envvar:`ZEPHYR_BASE`
+   
+     :envvar:`QEMU_BIN_PATH=/usr/local/bin`
 
 .. _Sphinx Inline Markup:
    http://sphinx-doc.org/markup/inline.html#inline-markup

--- a/source/clear-linux/reference/collaboration/documentation/inline.rst
+++ b/source/clear-linux/reference/collaboration/documentation/inline.rst
@@ -6,7 +6,7 @@ Inline Markup
 Sphinx supports a large number of inline markup elements called roles. The
 |CLOSIA| documentation encourages the use of as many roles as
 possible. Thus, you can use any additional roles supported by Sphinx
-not listed here. Please refer to the `Sphinx Inline Markup`_
+not listed here. Please refer to the `Sphinx reStructuredText Markup`_
 documentation for the full list of supported roles.
 
 The following markup is required in every instance unless otherwise
@@ -158,5 +158,5 @@ Environment Variables
    
      :envvar:`QEMU_BIN_PATH=/usr/local/bin`
 
-.. _Sphinx Inline Markup:
-   http://sphinx-doc.org/markup/inline.html#inline-markup
+.. _Sphinx reStructuredText Markup:
+   http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html

--- a/source/clear-linux/reference/collaboration/documentation/inline.rst
+++ b/source/clear-linux/reference/collaboration/documentation/inline.rst
@@ -34,20 +34,28 @@ the roles.
 
    ``:command:`command```
 
-* Use the `:option:` role to emphasize the name of a command option
-  with or without its value. This markup is usually employed in
-  combination with the `:command:` role. For example:
+* In most cases, use asterisks "*" to emphasize the name of a command
+  option. However, if you have defined an ``.. option::`` directive, you may use the `:option:` role. For example:
 
-   :option:`-f`
-   :option:`--all`
-   :option:`-o output.xsl`
+   Pandoc Options:
+
+   .. option:: -f
+   .. option:: --all
+   .. option:: -o <output.xsl>
+
    The :command:`pandoc` command can be used without the :option:`-o`
    option, creating an output file with the same name as the source
    but a different extension.
 
    Template:
+   
+   .. code-block:: rest
 
-   ``:option:`Option```
+      .. option: option
+
+         description of option 
+
+   ``:option:`option```
 
 * Use the `:file:` role to emphasize a filename or directory. Do not use the
   role inside a code-block but use it inside all notices that contain files

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -15,3 +15,4 @@ features.
    collaboration/collaboration
    compatible-kernels
    system-requirements
+   image-types

--- a/source/clear-linux/tutorials/azure.rst
+++ b/source/clear-linux/tutorials/azure.rst
@@ -390,7 +390,7 @@ For this tutorial, we are using the |CL| Basic SKU for our VM.
 
       If you have already defined your public/private SSH key pair and they
       are stored in your :file:`$HOME/.ssh` directory, you do not need to
-      include the :option:`--generate-ssh-keys` option.
+      include the *--generate-ssh-keys* option.
 
    Your output from this command will look similar to this output, where
    [user] is your user name:

--- a/source/clear-linux/tutorials/docker/docker.rst
+++ b/source/clear-linux/tutorials/docker/docker.rst
@@ -141,12 +141,12 @@ an the official Docker image for nginx, an open source reverse proxy server.
       detailed :command:`docker run` switches and syntax, refer to the 
       `Docker Documentation`_ .
 
-      * The :option:`--name` switch lets you provide a friendly name to
+      * The *--name* switch lets you provide a friendly name to
         target the container for future operations
 
-      * The :option:`-d` switch launches the container in the background
+      * The *-d* switch launches the container in the background
         
-      * The :option:`-p` switch allows the container's HTTP port (80) to be
+      * The *-p* switch allows the container's HTTP port (80) to be
         accessible from the Clear Linux host on port 8080
 
 #. You can access the Welcome to Nginx! splash page running in the container

--- a/source/clear-linux/tutorials/fmv.rst
+++ b/source/clear-linux/tutorials/fmv.rst
@@ -184,7 +184,7 @@ You can see the multiple clones of the `foo` function:
 The cloned functions use AVX2 registers and vectorized instructions. To
 verify, enter the following commands:
 
-.. code-block:: assembly
+.. code-block:: asm
 
     vpaddd (%r8,%rax,1),%ymm0,%ymm0
     vmovdqu %ymm0,(%rcx,%rax,1)
@@ -213,53 +213,54 @@ To follow the same approach with a package like FFT, we must use the
 For example, the :file:`fftw-3.3.6-pl2/tools/fftw-wisdom.c.patch` file
 generates the following patches:
 
-.. code-block:: git
+.. code-block:: diff
+   :linenos:
 
-      1 --- fftw-3.3.6-pl2/libbench2/verify-lib.c   2017-01-27 21:08:13.000000000 +0000
-      2 +++ fftw-3.3.6-pl2/libbench2/verify-lib.c~  2017-09-27 17:49:21.913802006 +0000
-      3 @@ -33,6 +33,7 @@
-      4
-      5  double dmax(double x, double y) { return (x > y) ? x : y; }
-      6
-      7 +__attribute__((target_clones("avx2","arch=atom","default")))
-      8  static double aerror(C *a, C *b, int n)
-      9  {
-     10       if (n > 0) {
-     11 @@ -111,6 +112,7 @@
-     12  }
-     13
-     14  /* make array hermitian */
-     15 +__attribute__((target_clones("avx2","arch=atom","default")))
-     16  void mkhermitian(C *A, int rank, const bench_iodim *dim, int stride)
-     17  {
-     18       if (rank == 0)
-     19 @@ -148,6 +150,7 @@
-     20  }
-     21
-     22  /* C = A + B */
-     23 +__attribute__((target_clones("avx2","arch=atom","default")))
-     24  void aadd(C *c, C *a, C *b, int n)
-     25  {
-     26       int i;
-     27 @@ -159,6 +162,7 @@
-     28  }
-     29
-     30  /* C = A - B */
-     31 +__attribute__((target_clones("avx2","arch=atom","default")))
-     32  void asub(C *c, C *a, C *b, int n)
-     33  {
-     34       int i;
-     35 @@ -170,6 +174,7 @@
-     36  }
-     37
-     38  /* B = rotate left A (complex) */
-     39 +__attribute__((target_clones("avx2","arch=atom","default")))
-     40  void arol(C *b, C *a, int n, int nb, int na)
-     41  {
-     42       int i, ib, ia;
-     43 @@ -192,6 +197,7 @@
-     44       }
-     45  }
+       --- fftw-3.3.6-pl2/libbench2/verify-lib.c   2017-01-27 21:08:13.000000000 +0000
+       +++ fftw-3.3.6-pl2/libbench2/verify-lib.c~  2017-09-27 17:49:21.913802006 +0000
+       @@ -33,6 +33,7 @@
+       
+        double dmax(double x, double y) { return (x > y) ? x : y; }
+       
+       +__attribute__((target_clones("avx2","arch=atom","default")))
+        static double aerror(C *a, C *b, int n)
+        {
+            if (n > 0) {
+       @@ -111,6 +112,7 @@
+       }
+       
+       /* make array hermitian */
+       +__attribute__((target_clones("avx2","arch=atom","default")))
+       void mkhermitian(C *A, int rank, const bench_iodim *dim, int stride)
+       {
+            if (rank == 0)
+       @@ -148,6 +150,7 @@
+       }
+     
+       /* C = A + B */
+       +__attribute__((target_clones("avx2","arch=atom","default")))
+       void aadd(C *c, C *a, C *b, int n)
+       {
+            int i;
+       @@ -159,6 +162,7 @@
+       }
+     
+       /* C = A - B */
+       +__attribute__((target_clones("avx2","arch=atom","default")))
+       void asub(C *c, C *a, C *b, int n)
+       {
+            int i;
+       @@ -170,6 +174,7 @@
+       }
+     
+       /* B = rotate left A (complex) */
+       +__attribute__((target_clones("avx2","arch=atom","default")))
+       void arol(C *b, C *a, int n, int nb, int na)
+       {
+            int i, ib, ia;
+       @@ -192,6 +197,7 @@
+            }
+       }
 
 With these patches, we can select where to apply the FMV technology making
 bringing architecture-based optimizations to application code even easier.

--- a/source/clear-linux/tutorials/multi-boot/multi-boot.rst
+++ b/source/clear-linux/tutorials/multi-boot/multi-boot.rst
@@ -53,7 +53,7 @@ RAM and a 360GB SSD. Table 1 lists the information specific to the
 installation of the tested operating systems.
 
 .. csv-table:: Table 1: OS specific installation information
-   :header: # , OS, Version, Partition Size [1], Swap Size [2], EFI Partition Size [3], Download Link
+   :header: # , OS, Version, Partition Size [#]_, Swap Size [#]_, EFI Partition Size [#]_, Download Link
 
    1,Clear Linux,16140,50 GB,8 GB,1 GB,https://download.clearlinux.org/releases/16140/clear/
    2,Windows,Server 2016,50 GB,N/A,Shared with #1,https://www.microsoft.com/en-us/cloud-platform/windows-server

--- a/source/clear-linux/tutorials/telemetry-backend/telemetry-backend.rst
+++ b/source/clear-linux/tutorials/telemetry-backend/telemetry-backend.rst
@@ -100,35 +100,35 @@ Run the deploy.sh script to install the backend server
 The :command:`deploy.sh` is a bash shell script that allows you to perform the
 following actions:
 
-* :option:`deploy` - install a complete instance of the telemetrics backend
+* *deploy* - install a complete instance of the telemetrics backend
   server and all required components. This is the default action if no
-  :option:`-a` argument is given on the command line.
-* :option:`install` - installs and enables all required components for the
+  *-a* argument is given on the command line.
+* *install* - installs and enables all required components for the
   telemetrics backend server.
-* :option:`migrate` - migrate database to new schema.
-* :option:`resetdb` - reset the database.
-* :option:`restart` - restart the nginx and uWSGI services.
-* :option:`uninstall` - uninstall all packages.
+* *migrate* - migrate database to new schema.
+* *resetdb* - reset the database.
+* *restart* - restart the nginx and uWSGI services.
+* *uninstall* - uninstall all packages.
 
   .. note::
   
-     The :option:`uninstall` option does not perform any actions if the 
+     The *uninstall* option does not perform any actions if the 
      distro is set to |CL| and will only uninstall packages if the distro is
      Ubuntu
 
 Next, we install the telemetrics backend server with the following options:
 
-* :option:`-a install` to perform an install
-* :option:`-d clr` to install to a |CL| distro
-* :option:`-H localhost` to set the domain to localhost
+* *-a install* to perform an install
+* *-d clr* to install to a |CL| distro
+* *-H localhost* to set the domain to localhost
 
 We do not need to set the following options since the values are set to the
 correct values we want by default:
 
-* :option:`-r https://github.com/clearlinux/telemetrics-backend` sets the
+* *-r https://github.com/clearlinux/telemetrics-backend* sets the
   repo location for :command:`git` to clone from.
-* :option:`-s master` to set the location, or branch.
-* :option:`-t git` to set the source type to git.
+* *-s master* to set the location, or branch.
+* *-t git* to set the source type to git.
 
 .. caution::
    The :file:`deploy.sh` shell script has minimal error checking and makes

--- a/source/conf.py
+++ b/source/conf.py
@@ -295,3 +295,6 @@ texinfo_documents = [
 
 # If true, generates permalinks on the HTML output.
 html_add_permalinks = ""
+
+#suppresses warnings for options that aren't referenced
+#suppress_warnings = ["ref.option"]


### PR DESCRIPTION
Fixes include the following:
1. Fixed :option: usage in concepts/restart.rst
1. Fixed broken link in /concepts/swupd-about.rst
1. Fixed mis-labaled code-blocks in maintenance/bulk-provision.rst
1. Fixed :option: usage in guides/maintenance/mixer.rst
1. Fixed broken link in guides/maintenance/swupd-guide.rst
1. Fixed broken links in reference/collaboration/documentation/documentation.rst
1. Updated :option: usage guidelines in reference/collaboration/documentation/inline.rst
1. Added page that was not included in TOC in reference/reference.rst
1. Fixed :option: usage in tutorials/azure.rst
1. Fixed :option: usage in tutorials/docker/docker.rst
1. Fixed mis-labeled code-blocks in tutorials/fmv.rst and replaced hard coded line numbers with auto generated
1. Fixed footnotes in tutorials/multi-boot/multi-boot.rst
1. Fixed :option: usage in tutorials/telemetry-backend/telemetry-backend.rst
1. Added suppress directive to conf.py (it is currently commented out)