### PR TITLE
Revised intro on Software update concepts page

### DIFF
--- a/source/clear-linux/concepts/swupd-about.rst
+++ b/source/clear-linux/concepts/swupd-about.rst
@@ -5,14 +5,14 @@ Software update
 
 |CLOSIA| does software updates differently than traditional Linux-based 
 operating systems. Where traditional distributions rely on packages for 
-software deployment, Clear Linux uses the concept of a *bundle* for 
+software deployment, |CL| uses the concept of a "bundle" for 
 deployment. Traditional Linux packages provide a particular utility or 
-library; Clear Linux bundles provide all necessary packages to enable a 
+library; |CL| bundles provide all necessary packages to enable a 
 specific function.
 
-With Clear Linux, updating equates to an entirely new OS version with a 
+With |CL|, updating equates to an entirely new OS version with a 
 specific set of bundles, as compared to a package-based distribution in 
-which packages may be updated individually. Clear Linux updates are 
+which packages may be updated individually. |CL| updates are 
 efficient, updating only changed files instead of entire packages.
 
 System administrators can customize or add bundles to the OS, while still 
@@ -28,10 +28,10 @@ binaries, we do not deploy software through packages. Instead, we use bundles
 to deploy software, where each bundle encapsulates a particular functionality 
 -- functionality that is enabled by composing all the required upstream 
 open-source projects and packages into one logical unit: a bundle. This 
-simplifies installing features on Clear Linux.
+simplifies installing features on |CL|.
 
 For additional resources regarding available bundles, useful bundle commands, 
-and compatible Clear Linux kernels, visit our :ref:`bundles-about` 
+and compatible |CL| kernels, visit our :ref:`bundles-about` 
 page.
 
 
@@ -56,7 +56,7 @@ non-trivial to define what "version" the system is and what software it
 is running without explicitly going through each system and inspecting
 every package.
 
-With Clear Linux, we need only track:
+With |CL|, we need only track:
 
 -  One single number
 
@@ -67,18 +67,18 @@ packages. This matters on a daily basis to system administrators, who
 need to determine which of their systems do not have the latest security
 fixes, or which combinations of software have been tested. Every release 
 of the same number is guaranteed to contain the same versions of software, 
-so there's no ambiguity between two systems running the same Clear Linux OS.
+so there's no ambiguity between two systems running the same version of |CL|.
 
 
 Updating
 ========
 
-Another notable difference between package-based distributions and Clear Linux
+Another notable difference between package-based distributions and |CL|
 is how updates are managed. On a package-based OS, system administrators update
 each individual package or piece of software to a newer (or older!) version. With
-Clear Linux, an update translates to an entirely new OS version, containing one 
+|CL|, an update translates to an entirely new OS version, containing one 
 or many updates.  It is not possible to update a piece of the system while 
-remaining on the same version of Clear Linux.
+remaining on the same version of |CL|.
 
 How is this useful? Although it seems, at first, like a huge restriction
 or limitation, this method has many non-obvious benefits. Imagine a
@@ -89,7 +89,7 @@ and/or code, rather than configuring environments or worrying about
 synchronizing versions and updates.  At the system admin level, it ensures 
 security is tighter and makes it far easier to monitor and update patches.
 
-Clear Linux promotes regular updating of the OS and will automatically check 
+|CL| promotes regular updating of the OS and will automatically check 
 for updates and apply them by default.
 
 To learn how to run an update of your system, visit our :ref:`swupd-guide` page.
@@ -98,7 +98,7 @@ To learn how to run an update of your system, visit our :ref:`swupd-guide` page.
 Update speed
 ============
 
-Software updates with Clear Linux are also efficient. Bundles simply describe 
+Software updates with |CL| are also efficient. Bundles simply describe 
 a set of files, and the update technology updates *only* files that actually 
 changed by using binary-delta technology for efficiency [1]_. Operating systems 
 that use packages as the unit of deployment require full package updates (thus
@@ -122,7 +122,7 @@ operators may have special needs and ideas. Therefore, we provide a
 :ref:`mixer tool <mixer>`. This tool allows users to customize and add bundles
 or even add their own software, while keeping the operating
 system and its updates as the basis. Using this tool, system administrators
-can focus on the custom pieces their deployments require while staying on
+can focus on the customization their deployments require while staying on
 a controlled update stream.
 
 To learn more about mixing, visit our :ref:`mixer-about` page.

--- a/source/clear-linux/concepts/swupd-about.rst
+++ b/source/clear-linux/concepts/swupd-about.rst
@@ -3,24 +3,36 @@
 Software update
 ###############
 
-Clear Linux OS for Intel® Architecture does software updates differently than traditional Linux-based operating systems. Where traditional distributions rely on packages for software deployment, Clear Linux uses the concept of a bundle for deployment. Traditional Linux packages provide a particular utility or library, whereas Clear Linux bundles provide a specific function and include all necessary dependencies and packages.
+|CLOSIA| does software updates differently than traditional Linux-based 
+operating systems. Where traditional distributions rely on packages for 
+software deployment, Clear Linux uses the concept of a *bundle* for 
+deployment. Traditional Linux packages provide a particular utility or 
+library; Clear Linux bundles provide all necessary packages to enable a 
+specific function.
 
-With Clear Linux, updating equates to an entirely new OS version with a specific set of bundles, as compared to a package-based distribution in which packages may be updated individually. Clear Linux updates are efficient, updating only changed files instead of entire packages.
+With Clear Linux, updating equates to an entirely new OS version with a 
+specific set of bundles, as compared to a package-based distribution in 
+which packages may be updated individually. Clear Linux updates are 
+efficient, updating only changed files instead of entire packages.
 
-System administrators can customize or add bundles to the OS, while still taking advantage of a controlled update stream. This enables system administrators to focus on the pieces that make their deployment unique.
+System administrators can customize or add bundles to the OS, while still 
+taking advantage of a controlled update stream. This enables system 
+administrators to focus on the pieces that make their deployment unique.
 
 
 Bundles
 =======
 
-While we use the concept of "packages" to manage compiling source code into
-installable binaries, we do not deploy software through packages. Instead,
-we provide "bundles" which operate as a self-contained set of functionality
-for the system administrator -- functionality that gets enabled by composing
-all the required upstream open-source projects into one logical unit: a
-bundle.
+While we use packages to manage compiling source code into installable 
+binaries, we do not deploy software through packages. Instead, we use bundles 
+to deploy software, where each bundle encapsulates a particular functionality 
+-- functionality that is enabled by composing all the required upstream 
+open-source projects and packages into one logical unit: a bundle. This 
+simplifies installing features on Clear Linux.
 
-For additional resources regarding available bundles, useful bundle commands, and compatible Clear Linux kernels, visit our :ref:`Bundles <bundles-about>` page.
+For additional resources regarding available bundles, useful bundle commands, 
+and compatible Clear Linux kernels, visit our :ref:`bundles-about` 
+page.
 
 
 Versioning
@@ -30,13 +42,13 @@ In a traditional distribution, the process of describing current software
 versioning usually involves:
 
 -  Listing and keeping track of the current OS release (generally
-   uninformative about any singular packages or functionality),
+   uninformative about any singular packages or functionality).
 
--  Keeping track of packages and repositories being used, updating them
-   individually,
+-  Keeping track of packages and repositories being used, and updating them
+   individually.
 
 -  Listing and tracking every package available and installed on the
-   system, none of which are directly tied to the current OS release
+   system, none of which are directly tied to the current OS release.
 
 This can be done effectively, but given the nearly endless combinations of
 packages and versions of packages a server may have, it quickly becomes
@@ -44,7 +56,7 @@ non-trivial to define what "version" the system is and what software it
 is running without explicitly going through each system and inspecting
 every package.
 
-With the Clear Linux OS for Intel Architecture, we need only track:
+With Clear Linux, we need only track:
 
 -  One single number
 
@@ -53,10 +65,9 @@ describe the versions of all the software on the OS. Each build is
 composed of a specific set of bundles made from a particular version of
 packages. This matters on a daily basis to system administrators, who
 need to determine which of their systems do not have the latest security
-fixes, or which combinations of software have been tested, and on what
-other pieces. Every release of the same number is guaranteed to contain
-the same versions of software, so there's no ambiguity between two
-systems running the same Clear Linux OS for Intel Architecture.
+fixes, or which combinations of software have been tested. Every release 
+of the same number is guaranteed to contain the same versions of software, 
+so there's no ambiguity between two systems running the same Clear Linux OS.
 
 
 Updating
@@ -65,39 +76,32 @@ Updating
 Another notable difference between package-based distributions and Clear Linux
 is how updates are managed. On a package-based OS, system administrators update
 each individual package or piece of software to a newer (or older!) version. With
-Clear Linux OS for Intel Architecture, an update translates to an entirely new
-OS version, containing one or many updates.  It is not possible to update a
-piece of the system while remaining on the same version of Clear Linux.
+Clear Linux, an update translates to an entirely new OS version, containing one 
+or many updates.  It is not possible to update a piece of the system while 
+remaining on the same version of Clear Linux.
 
 How is this useful? Although it seems, at first, like a huge restriction
 or limitation, this method has many non-obvious benefits. Imagine a
 cloud environment composed of numerous machines.  Here, a homogeneous set of
 software makes sense -- from the system administrator's level down to the
-user level. Homogeneous systems allow users the ability to focus on their
-contributions and/or code, rather than configuring environments or worrying
-about synchronizing versions and updates.  At the system admin level, it
-ensures security is tighter and makes it far easier to monitor and update
-patches.
+user level. Homogeneous systems allow users to focus on their contributions 
+and/or code, rather than configuring environments or worrying about 
+synchronizing versions and updates.  At the system admin level, it ensures 
+security is tighter and makes it far easier to monitor and update patches.
 
-Clear Linux OS will automatically check for updates and apply them. This default
-can be disabled by running::
+Clear Linux promotes regular updating of the OS and will automatically check 
+for updates and apply them by default.
 
-    # swupd autoupdate --disable
+To learn how to run an update of your system, visit our :ref:`swupd-guide` page.
 
-And reenabled by running::
-
-    # swupd autoupdate --enable
-
-To learn how to run an update of your system, visit our :ref:`Use swupd <swupd-guide>` page.
 
 Update speed
 ============
 
-Software updates with Clear Linux OS for Intel Architecture are also
-efficient. Bundles simply describe a set of files, and the update
-technology updates *only* files that actually changed by using
-binary-delta technology for efficiency [1]_. Operating systems that use
-packages as the unit of deployment require full package updates (thus
+Software updates with Clear Linux are also efficient. Bundles simply describe 
+a set of files, and the update technology updates *only* files that actually 
+changed by using binary-delta technology for efficiency [1]_. Operating systems 
+that use packages as the unit of deployment require full package updates (thus
 hogging resources), even when one small file in that package has changed.
 
 It is quite common for a full OS update fixing a security hole to be
@@ -109,6 +113,10 @@ those bits that changed, yielding very small update content (deltas)
 that can be applied exceedingly fast.  As a result, major security patches
 and core update take merely seconds.
 
+
+Customize the OS
+================
+
 While we realize our definition of bundles makes sense to us, data center
 operators may have special needs and ideas. Therefore, we provide a
 :ref:`mixer tool <mixer>`. This tool allows users to customize and add bundles
@@ -117,7 +125,8 @@ system and its updates as the basis. Using this tool, system administrators
 can focus on the custom pieces their deployments require while staying on
 a controlled update stream.
 
+To learn more about mixing, visit our :ref:`mixer-about` page.
 
 
-.. [1] The software update technology for Clear Linux* OS for Intel
-   Architecture was first presented at the Linux Plumbers conference in 2012.
+.. [1] The software update technology for |CLOSIA| was first presented at the 
+   Linux Plumbers conference in 2012.

--- a/source/clear-linux/concepts/swupd-about.rst
+++ b/source/clear-linux/concepts/swupd-about.rst
@@ -3,43 +3,30 @@
 Software update
 ###############
 
-The traditional way
-===================
+Clear Linux OS for Intel® Architecture does software updates differently than traditional Linux-based operating systems. Where traditional distributions rely on packages for software deployment, Clear Linux uses the concept of a bundle for deployment. Traditional Linux packages provide a particular utility or library, whereas Clear Linux bundles provide a specific function and include all necessary dependencies and packages.
 
-Traditional Linux-based operating systems are often a mix of several
-hundred, if not thousands, of open source projects. To make them
-manageable, most distributions use the concept of "packages" to configure
-and compile source code into binaries for installation.
+With Clear Linux, updating equates to an entirely new OS version with a specific set of bundles, as compared to a package-based distribution in which packages may be updated individually. Clear Linux updates are efficient, updating only changed files instead of entire packages.
 
-Many distributions then combine these compiled binaries into so-called
-packages, resolving dependencies and providing everything needed to
-install. This is the granularity at which typical distributions deploy
-their software, enabling system administrators to install and update
-each package individually or as a set, using tools such as ``yum`` and
-``apt-get``.
+System administrators can customize or add bundles to the OS, while still taking advantage of a controlled update stream. This enables system administrators to focus on the pieces that make their deployment unique.
 
-The Clear way
-=============
-
-Clear Linux OS for Intel® Architecture does things a little differently.
-The following are a few notable features that distinguish it from
-standard OSes: bundles, versioning, updating, and update speed.
 
 Bundles
--------
+=======
 
-While we use the concept of packages to manage compiling source code into
+While we use the concept of "packages" to manage compiling source code into
 installable binaries, we do not deploy software through packages. Instead,
 we provide "bundles" which operate as a self-contained set of functionality
 for the system administrator -- functionality that gets enabled by composing
 all the required upstream open-source projects into one logical unit: a
 bundle.
 
+For additional resources regarding available bundles, useful bundle commands, and compatible Clear Linux kernels, visit our :ref:`Bundles <bundles-about>` page.
+
 
 Versioning
-----------
+==========
 
-On a traditional distribution, the process of describing current software
+In a traditional distribution, the process of describing current software
 versioning usually involves:
 
 -  Listing and keeping track of the current OS release (generally
@@ -73,7 +60,7 @@ systems running the same Clear Linux OS for Intel Architecture.
 
 
 Updating
---------
+========
 
 Another notable difference between package-based distributions and Clear Linux
 is how updates are managed. On a package-based OS, system administrators update
@@ -101,9 +88,10 @@ And reenabled by running::
 
     # swupd autoupdate --enable
 
+To learn how to run an update of your system, visit our :ref:`Use swupd <swupd-guide>` page.
 
 Update speed
-------------
+============
 
 Software updates with Clear Linux OS for Intel Architecture are also
 efficient. Bundles simply describe a set of files, and the update
@@ -129,7 +117,7 @@ system and its updates as the basis. Using this tool, system administrators
 can focus on the custom pieces their deployments require while staying on
 a controlled update stream.
 
-To learn how to run an update of your system, visit our :ref:`using swupd <swupd-guide>` page.
+
 
 .. [1] The software update technology for Clear Linux* OS for Intel
    Architecture was first presented at the Linux Plumbers conference in 2012.


### PR DESCRIPTION
- Updated intro, emphasis on introducing CL update compared to traditional update
- Removed the (repeated) definition of the traditional way, already used elsewhere
- Removed intro paragraph heading to be more consistent with layout of other concept pages
- Added link to bundles page from bundles section
- Moved 'using swupd' link to Updating section (from bottom of page where it came after mixer discussion)

Signed-off-by: Kristal Dale <kristal.dale@intel.com>