### PR TITLE
Fixed TM and brand references

### DIFF
--- a/source/clear-linux/reference/compatible-hardware.rst
+++ b/source/clear-linux/reference/compatible-hardware.rst
@@ -18,7 +18,7 @@ grow.
       -
 
     * - Intel® Core™ i5-6560U
-      - Dell XPS 13 9350\*
+      - Dell XPS\* 13 9350
 
     * - Intel® Celeron® J3455
       - NUC6CAYS
@@ -30,10 +30,10 @@ grow.
       -
 
     * - Intel® Core™ i9-7900X
-      - Gigabyte X299\*
+      - Gigabyte\* X299
 
     * - Intel® Core™ i3-4130
-      - Lenovo Thinkserver TS140\*
+      - Lenovo Thinkserver\* TS140
 
     * - Intel® Core™ i7-7567U
       - NUC7i7BNH
@@ -50,22 +50,22 @@ grow.
     * - Intel® Core™ i5-7300U
       - NUC7i5DNHE
 
-    * - Intel® Xeon® Gold 6138 Processor
+    * - Intel® Xeon® Gold 6138
       -
 
-    * - Intel® Xeon® Processor E5-2699A v4
-      - Dell PowerEdge R630\*
+    * - Intel® Xeon® E5-2699A v4
+      - Dell PowerEdge\* R630
 
-    * - Intel® Xeon® Processor E5-2620 v3
+    * - Intel® Xeon® E5-2620 v3
       -
 
     * - Intel® Core™ i5-6600
-      - Gigabyte Z170X-UD5\*
+      - Gigabyte\* Z170X-UD5
 
     * - Intel® Core™ i5-4250U
       - D54250WYK
 
-    * - Intel® Xeon® Processor E5-2699 v3
+    * - Intel® Xeon® E5-2699 v3
       - S2600WT2
 
     * - Intel® Atom™ J3455
@@ -75,19 +75,19 @@ grow.
       - 0W23H8
 
     * - Intel® Atom™ C2750
-      - SuperMicro A1SAi\*
+      - SuperMicro\* A1SAi
 
     * - Intel® Atom™ E3825
       - CircuitCo MinnowBoard MAX\*
 
     * - Intel® Core™ i7-8700
-      - Gigabyte H370\* WIFI
+      - Gigabyte\* H370 WIFI
 
     * - Intel® Core™ i7-3667U
-      - Lenovo ThinkPad X1 Carbon\* laptop
+      - Lenovo ThinkPad\* X1 Carbon laptop
 
     * - Intel® Core™ i5-4210U
-      - Dell XPS 13\* laptop
+      - Dell XPS\* 13 laptop
 
     * - Intel® Celeron® J3455
       - NUC6CAYB
@@ -102,7 +102,7 @@ grow.
       - NUC5I7RYH
 
     * - Intel® Core™ i7-4700MQ
-      - Lenovo ThinkPad T540p\*
+      - Lenovo ThinkPad\* T540p
 
     * - Intel® Core™ i7-5557U
       - NUC5I7RYB


### PR DESCRIPTION
As discussed removed extra processor mentions and shifted other TM * to better match standard usage