### PR TITLE
asm code-block is not recognized by sphinx 1.2.2

### DIFF
--- a/source/clear-linux/tutorials/fmv.rst
+++ b/source/clear-linux/tutorials/fmv.rst
@@ -184,7 +184,7 @@ You can see the multiple clones of the `foo` function:
 The cloned functions use AVX2 registers and vectorized instructions. To
 verify, enter the following commands:
 
-.. code-block:: asm
+:: 
 
     vpaddd (%r8,%rax,1),%ymm0,%ymm0
     vmovdqu %ymm0,(%rcx,%rax,1)


### PR DESCRIPTION
Assembly blocks aren't recognized by lexer, so I changed it to "::"