### PR TITLE
Omit internal doc TOC; only two subheads, unnecessary.

### DIFF
--- a/source/clear-linux/guides/maintenance/swupd-search.rst
+++ b/source/clear-linux/guides/maintenance/swupd-search.rst
@@ -3,10 +3,6 @@
 Use swupd search to find bundles
 ################################
 
-.. contents:: 
-   :local: 
-   :depth: 2
-
 This document shows you how to use `swupd search` to find and add
 bundles. 
 


### PR DESCRIPTION
Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>