### PR TITLE
Omits toctree ref to clear-containers; resets maxdepth to 1.

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -1,14 +1,13 @@
 .. Clear Technologies documentation master file.
 
-Clear technologies - Documentation
-##################################
+Clear Linux - Documentation
+###########################
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    clear-linux/clear-linux
-   clear-containers/clear-containers
-
+   
 License and disclaimers
 =======================
 


### PR DESCRIPTION
Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>