### PR TITLE
Update the remaining landing pages for consistency

### DIFF
--- a/source/clear-linux/concepts/concepts.rst
+++ b/source/clear-linux/concepts/concepts.rst
@@ -3,7 +3,8 @@
 Concepts
 ########
 
-Learn about |CL-ATTR| features and what makes |CL| different from other Linux distributions. 
+Learn about |CL-ATTR| features and what makes |CL| different from other 
+Linux distributions. 
 
 * :ref:`bundles-about`
   
@@ -11,15 +12,18 @@ Learn about |CL-ATTR| features and what makes |CL| different from other Linux di
   
 * :ref:`swupd-about`
   
-  In |CL|, an update translates to an entirely new OS version, with one or many updates.
+  In |CL|, an update translates to an entirely new OS version, with one 
+  or many updates.
 
 * :ref:`mixer-about`
   
-  |CL| enables customization of your OS or customizing your own |CL|-based distribution.  
+  |CL| enables customization of your OS or customizing your own |CL|-based 
+  distribution.  
 
 * :ref:`telemetry-about`
   
-  |CL| provides a customizable telemetry solution, that helps developers detect and address issues.
+  |CL| provides a customizable telemetry solution, that helps developers 
+  detect and address issues.
 
 .. toctree::
    :hidden:

--- a/source/clear-linux/concepts/concepts.rst
+++ b/source/clear-linux/concepts/concepts.rst
@@ -3,12 +3,26 @@
 Concepts
 ########
 
-The concepts section provides content for a deeper understanding of the
-features of |CLOSIA|. These concepts attempt to provide all the technical
-details relevant to the |CL| features.
+Learn about |CL-ATTR| features and what makes |CL| different from other Linux distributions. 
+
+* :ref:`bundles-about`
+  
+  Instead of traditional packages, |CL| uses bundles to deploy software. 
+  
+* :ref:`swupd-about`
+  
+  In |CL|, an update translates to an entirely new OS version, with one or many updates.
+
+* :ref:`mixer-about`
+  
+  |CL| enables customization of your OS or customizing your own |CL|-based distribution.  
+
+* :ref:`telemetry-about`
+  
+  |CL| provides a customizable telemetry solution, that helps developers detect and address issues.
 
 .. toctree::
-   :maxdepth: 2
+   :hidden:
 
    swupd-about
    mixer-about

--- a/source/clear-linux/guides/guides.rst
+++ b/source/clear-linux/guides/guides.rst
@@ -3,19 +3,16 @@
 Guides
 ######
 
-Our Guides: 
-
-*  Provide a critical, fundamental understanding of |CL| features
-*  Show you how to leverage the full feature set of |CL|
-*  Enhance your productivity when using |CL| 
-
-
-The following guides provide step-by-step instructions for tasks that come
-after completing the |CL| :ref:`installation <get-started>`.
+Use our guides to learn how to complete common tasks in |CL-ATTR| and use 
+|CL| native features effectively. 
+     
+Our guides assume you have a basic understanding of |CL| :ref:`concepts` 
+and a |CL| installation. For details regarding installing |CL|, see 
+:ref:`get-started`.
 
 .. toctree::
-   :maxdepth: 2
-
+   :hidden:
+   
    maintenance/maintenance
    network/network
    deploy-at-scale

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -3,7 +3,8 @@
 Reference
 #########
 
-This section provides additional information for use of |CL-ATTR| and its features.
+This section provides additional information for use of |CL-ATTR| and 
+its features.
 
 .. toctree::
    :hidden:

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -3,11 +3,10 @@
 Reference
 #########
 
-This section provides additional information on the |CL| project and |CL|
-features.
+This section provides additional information for use of |CL-ATTR| and its features.
 
 .. toctree::
-   :maxdepth: 2
+   :hidden:
 
    compatible-hardware
    bundle-commands


### PR DESCRIPTION
- Hide toctree
- CL substitution update
- Update intro text for Concepts and Guides to have consistent style with other intro text.