### PR TITLE
fixed example URLs that were not supposed to be hyperlinks

### DIFF
--- a/source/clear-linux/guides/maintenance/bulk-provision.rst
+++ b/source/clear-linux/guides/maintenance/bulk-provision.rst
@@ -143,7 +143,7 @@ Configuration
       # MAC address,role
       default,ciao
 
-#. Verify the following URLs are accessible:
+#. Verify the following URLs are accessible on your local network:
 
    * ``http://192.168.1.1:60000/icis/static/ister/ister.conf``
    * ``http://192.168.1.1:60000/icis/static/ister/ister.json``

--- a/source/clear-linux/guides/maintenance/bulk-provision.rst
+++ b/source/clear-linux/guides/maintenance/bulk-provision.rst
@@ -145,11 +145,11 @@ Configuration
 
 #. Verify the following URLs are accessible:
 
-   * http://192.168.1.1:60000/icis/static/ister/ister.conf
-   * http://192.168.1.1:60000/icis/static/ister/ister.json
-   * http://192.168.1.1:60000/icis/get_config/<MAC address>
-   * http://192.168.1.1:60000/icis/get_role/<role>
-   * http://192.168.1.1:60000/ipxe/ipxe_boot_script.txt
+   * ``http://192.168.1.1:60000/icis/static/ister/ister.conf``
+   * ``http://192.168.1.1:60000/icis/static/ister/ister.json``
+   * ``http://192.168.1.1:60000/icis/get_config/<MAC address>``
+   * ``http://192.168.1.1:60000/icis/get_role/<role>``
+   * ``http://192.168.1.1:60000/ipxe/ipxe_boot_script.txt``
 
 #. Power on the PXE client and watch it boot and install |CL|.
 


### PR DESCRIPTION
bulk-provision.rst contains example URLs that were not meant to be links. Used `` to render them as inline code. Also made a small wording change to add clarity.