### PR TITLE
fixed link to sphinx-doc.org

### DIFF
--- a/source/clear-linux/reference/collaboration/documentation/rest.rst
+++ b/source/clear-linux/reference/collaboration/documentation/rest.rst
@@ -14,7 +14,7 @@ documentation. This section contains the preferred methods for using the
 `Sphinx documentation`_ for the complete list of available markup and use
 as much markup as possible.
 
-.. _Sphinx documentation: http://www.sphinx-doc.org/en/stable/markup/index.html
+.. _Sphinx documentation: http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 
 Remember: **Changing incorrect markup is easier than adding markup from
 scratch.**


### PR DESCRIPTION
@mvincerx since you’re the last person to work on this, I figured I’d run it by you.

There is one broken link that impacts two files: rest.rst and cross.rst (since it includes content from rest.rst)

The link that’s broken is this one: http://www.sphinx-doc.org/en/stable/markup/index.html

I’d like to replace it with: http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
