### PR TITLE
Re-enable show toctree for tutorials landing page.

### DIFF
--- a/source/clear-linux/tutorials/tutorials.rst
+++ b/source/clear-linux/tutorials/tutorials.rst
@@ -5,16 +5,15 @@ Tutorials
 
 This section offers a range of tutorials that demonstrate:
 
-* |CL-ATTR| features for cloud, client, distributed processing, and virtual environments
+* |CL-ATTR| features for cloud, client, distributed processing,
+  and virtual environments
 * Use of |CL| with third-party tools
 * Development possibilities of |CL| with specific use cases
 
 Explore our tutorials to discover what you can do with |CL|!
 
-
 .. toctree::
-   :hidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    wordpress/wordpress
    flatpak/flatpak


### PR DESCRIPTION
Remove hidden from toctree. Update maxdepth to 1.

Signed-off-by: Kristal Dale <kristal.dale@intel.com>