### PR TITLE
bundles.html: removes inline styles to address error:

### DIFF
--- a/source/clear-linux/reference/bundles/bundles.html
+++ b/source/clear-linux/reference/bundles/bundles.html
@@ -1,8 +1,3 @@
-<head>
-   <title>Bundles in Clear Linux OS for Intel® Architecture</title>
-   
-</head>
-
 <table>
    <thead>
     <tr>

--- a/source/clear-linux/reference/bundles/bundles.html
+++ b/source/clear-linux/reference/bundles/bundles.html
@@ -1,51 +1,6 @@
 <head>
    <title>Bundles in Clear Linux OS for Intel® Architecture</title>
-   <style type="text/css">
-   table {
-      margin: 2em;
-      border: 1px solid #e0e0e0;
-      border-collapse: collapse;
-      width: auto;
-   }
-
-   th {
-      align: center;
-      padding: 0.33em;
-      border: #ccc solid 1px;
-      background-color: #555;
-      color: #fff;
-      text-transform: uppercase;
-      font-size: 1.21em
-   }
-
-   tbody tr:nth-child(odd) {
-      background-color: #e0e0e0;
-   }
-
-   .bundlename {
-      font-family: monospace;
-      font-size: 1.13em;
-      font-weight: bolder;
-      padding-left: 0.42em;
-   }
-
-   .bundlestatus {
-      font-family: sans;
-      font-weight: lighter;
-   }
-
-   .bundledesc {
-      font-size: 0.93em;
-      line-height: 0.88em;
-      font-family: sans;
-   }
-
-   li,
-   ul {
-      margin-left: 0.53em;
-      padding-left: 0.23em;
-   }
-   </style>
+   
 </head>
 
 <table>


### PR DESCRIPTION
- Root cause unknown; likely PHP- or Drupal-related changes made
- Inline styles are overwritten by higher-level css
- Previous PR 277 did NOT include any edits to bundle.html


Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>