### PR TITLE
Update product name substitution in reference section

### DIFF
--- a/source/clear-linux/reference/bundle-commands.rst
+++ b/source/clear-linux/reference/bundle-commands.rst
@@ -22,7 +22,7 @@ To search for bundles and their contents, enter:
 
 .. code-block:: bash
 
-   sudo swupd search [bundle name]  
+   sudo swupd search [bundle name]
 
 To add a bundle, enter:
 
@@ -30,14 +30,14 @@ To add a bundle, enter:
 
    sudo swupd bundle-add [bundle name]
 
-Additional information 
+Additional information
 ======================
 
 For additional :command:`swupd` commands, enter:
 
 .. code-block:: bash
 
-   swupd --help 
+   swupd --help
 
 To reference the :command:`swupd` man page, enter:
 

--- a/source/clear-linux/reference/bundles/bundles.rst
+++ b/source/clear-linux/reference/bundles/bundles.rst
@@ -3,8 +3,8 @@
 Available bundles
 #################
 
-This document provides a current list of `available bundles`_ as 
-of ``12 September 2018``.                                      
+This document provides a current list of `available bundles`_ as
+of ``12 September 2018``.
 
 Bundle list
 ===========

--- a/source/clear-linux/reference/collaboration/collaboration.rst
+++ b/source/clear-linux/reference/collaboration/collaboration.rst
@@ -3,7 +3,7 @@
 Collaboration guidelines
 ########################
 
-Thank you for your interest in collaborating with the |CLOSIA|. This guide
+Thank you for your interest in collaborating with the |CL-ATTR|. This guide
 details the best ways to collaborate with the |CL| team.
 Additionally, this guide provides the guidelines our documentation follows.
 Thus, you can help improve our documents with your use case tutorials,

--- a/source/clear-linux/reference/collaboration/documentation/code.rst
+++ b/source/clear-linux/reference/collaboration/documentation/code.rst
@@ -3,7 +3,7 @@
 Code blocks
 ###########
 
-Collaborating to the |CLOSIA| is all about code. Therefore, your
+Collaborating to the |CL-ATTR| is all about code. Therefore, your
 documentation must include as many code examples as possible. You can write
 code examples directly in the documentation or include them from a source
 file. Use these guidelines to insert code blocks to your documentation:

--- a/source/clear-linux/reference/collaboration/documentation/code.rst
+++ b/source/clear-linux/reference/collaboration/documentation/code.rst
@@ -3,7 +3,7 @@
 Code blocks
 ###########
 
-Collaborating to the |CL-ATTR| is all about code. Therefore, your
+Contributing to the |CL-ATTR| is all about code. Therefore, your
 documentation must include as many code examples as possible. You can write
 code examples directly in the documentation or include them from a source
 file. Use these guidelines to insert code blocks to your documentation:

--- a/source/clear-linux/reference/collaboration/documentation/contents.rst
+++ b/source/clear-linux/reference/collaboration/documentation/contents.rst
@@ -4,7 +4,7 @@
 Contents directive
 ##################
 
-For |CL| documentation that has three or more sections, use the `contents::`
+For |CL-ATTR| documentation that has three or more sections, use the `contents::`
 directive as shown in the example below. This directive automatically captures the headings (and 
 subheadings if used) as specified in the value given after `:depth:`. Adding this directive to 
 longer documents allows users to quickly navigate to the desired section.
@@ -24,8 +24,8 @@ longer documents allows users to quickly navigate to the desired section.
 
 EXAMPLE: 
 
-Clear Linux Guide Example  
-*************************
+Guide Example  
+*************
 
 Introduction
 ============

--- a/source/clear-linux/reference/collaboration/documentation/cross.rst
+++ b/source/clear-linux/reference/collaboration/documentation/cross.rst
@@ -12,7 +12,7 @@ consistency of the documents.
 Internal cross-references
 *************************
 
-An internal cross-reference is a reference to a location within the |CLOSIA|
+An internal cross-reference is a reference to a location within the |CL-ATTR|
 documentation. Use explicit markup labels and the ``:ref:`` role to create
 cross references to headings, figures, and code examples as needed. Every
 file must have a label before the title, which is identical to the file's 
@@ -127,7 +127,7 @@ Use this template to add a hyperlink with a separated definition:
 The include directive 
 *********************
 
-Clear Linux documentation also uses the ``.. include::`` 
+|CL| documentation also uses the ``.. include::`` 
 directive to include a portion of another reST file. 
 
 Use the ``.. include::`` directive to show a select portion of a file.  

--- a/source/clear-linux/reference/collaboration/documentation/documentation.rst
+++ b/source/clear-linux/reference/collaboration/documentation/documentation.rst
@@ -3,7 +3,7 @@
 Documentation contribution guidelines
 #####################################
 
-The |CLOSIA| documentation contribution guidelines provide detailed information
+The |CL-ATTR| documentation contribution guidelines provide detailed information
 about the scope and purpose of the documentation, the accepted writing style,
 and the markup used.
 

--- a/source/clear-linux/reference/collaboration/documentation/grammar.rst
+++ b/source/clear-linux/reference/collaboration/documentation/grammar.rst
@@ -4,7 +4,7 @@ Grammar guide
 #############
 
 This guide provides valuable insight into the correct grammar for the
-|CLOSIA| documentation. It covers subjects such as capitalization, verbs,
+|CL-ATTR| documentation. It covers subjects such as capitalization, verbs,
 hyphenation, possessives, and contractions.
 
 Capitalization

--- a/source/clear-linux/reference/collaboration/documentation/headings.rst
+++ b/source/clear-linux/reference/collaboration/documentation/headings.rst
@@ -6,7 +6,7 @@ Headings
 Descriptive and brief headings are crucial to the quality of the
 documentation. Sphinx uses the headings within the
 :abbr:`ReST (RestructuredText)` files to generate the navigation of the HTML
-output and the outlines of the PDF files. The |CLOSIA| publishes the
+output and the outlines of the PDF files. The |CL-ATTR| publishes the
 documentation as HTML making consistent heading levels extremely important.
 
 In addition to the title of the file, only three levels of headings are

--- a/source/clear-linux/reference/collaboration/documentation/images.rst
+++ b/source/clear-linux/reference/collaboration/documentation/images.rst
@@ -8,7 +8,7 @@ sometimes is difficult to explain using words alone. Well-planned graphics
 reduce the amount of text required to explain information. Non-native English
 readers rely heavily on graphics because graphics enhance their understanding of the text.
 
-Follow these guidelines when creating graphics for the |CLOSIA|:
+Follow these guidelines when creating graphics for the |CL-ATTR|:
 
 * Save the image files in a :file:`figures` folder. The folder must be found
   at the same level as the file containing the text.

--- a/source/clear-linux/reference/collaboration/documentation/inline.rst
+++ b/source/clear-linux/reference/collaboration/documentation/inline.rst
@@ -4,7 +4,7 @@ Inline Markup
 *************
 
 Sphinx supports a large number of inline markup elements called roles. The
-|CLOSIA| documentation encourages the use of as many roles as
+|CL-ATTR| documentation encourages the use of as many roles as
 possible. Thus, you can use any additional roles supported by Sphinx
 not listed here. Please refer to the `Sphinx reStructuredText Markup`_
 documentation for the full list of supported roles.

--- a/source/clear-linux/reference/collaboration/documentation/language.rst
+++ b/source/clear-linux/reference/collaboration/documentation/language.rst
@@ -4,13 +4,13 @@ Language reference guide
 ########################
 
 This section describes acceptable usage of the English language in the
-|CLOSIA| documentation. It includes information about words use,
+|CL-ATTR| documentation. It includes information about words use,
 punctuation, and grammar. This guide does not replace a professional
 writer's review but is intended to help collaborators submit consistent
 contributions.
 
 To make translations easier and to make the content accessible to non-native
-speakers, |CLOSIA| uses Simple English. However, we have not implemented any
+speakers, |CL-ATTR| uses Simple English. However, we have not implemented any
 controlled language standards.
 
 .. toctree::

--- a/source/clear-linux/reference/collaboration/documentation/punctuation.rst
+++ b/source/clear-linux/reference/collaboration/documentation/punctuation.rst
@@ -4,7 +4,7 @@ Punctuation guide
 #################
 
 This section contains all the information regarding the correct use of
-punctuation for the |CLOSIA| documentation.
+punctuation for the |CL-ATTR| documentation.
 
 Commas, Semicolons, and Colons
 ******************************

--- a/source/clear-linux/reference/collaboration/documentation/rest.rst
+++ b/source/clear-linux/reference/collaboration/documentation/rest.rst
@@ -8,7 +8,7 @@ RestructuredText guide
 Overview
 ********
 
-The |CLOSIA| uses Sphinx and RestructuredText as authoring tools for its
+The |CL-ATTR| uses Sphinx and RestructuredText as authoring tools for its
 documentation. This section contains the preferred methods for using the
 :abbr:`ReST (RestructuredText)` markup on your documents. Please refer to the
 `Sphinx documentation`_ for the complete list of available markup and use

--- a/source/clear-linux/reference/collaboration/documentation/simple.rst
+++ b/source/clear-linux/reference/collaboration/documentation/simple.rst
@@ -12,7 +12,7 @@ Simple English improves the clarity of procedural technical writing,
 makes translation easier, and improves comprehension for people whose
 first language is not English.
 
-|CLOSIA| does not use controlled language, which restricts the writer's
+|CL-ATTR| does not use controlled language, which restricts the writer's
 vocabulary to a list of approved words. However, we do strongly recommend
 using the language principles described below.
 

--- a/source/clear-linux/reference/collaboration/documentation/structures.rst
+++ b/source/clear-linux/reference/collaboration/documentation/structures.rst
@@ -4,7 +4,7 @@ Consistent content structures guide
 ###################################
 
 This section guides you through the different content structures used in the
-|CLOSIA| documentation. This section serves as an example of the correct use
+|CL-ATTR| documentation. This section serves as an example of the correct use
 of markup. Refer to our :ref:`rest` to learn more about using
 restructuredText to author your content.
 

--- a/source/clear-linux/reference/collaboration/documentation/tables.rst
+++ b/source/clear-linux/reference/collaboration/documentation/tables.rst
@@ -5,7 +5,7 @@ Tables
 
 Tables must only be used for information that is either too numerous or too
 related for a list to be appropriate. The smallest acceptable table is 2x2
-not counting the table header. The |CLOSIA| uses special ReStructuredText
+not counting the table header. The |CL-ATTR| uses special ReStructuredText
 markup to make including tables easier. If you plan on adding a table
 consider transforming it into a list before you embark on creating a table.
 Follow these general guidelines:

--- a/source/clear-linux/reference/compatible-hardware.rst
+++ b/source/clear-linux/reference/compatible-hardware.rst
@@ -4,10 +4,10 @@ Compatible Hardware
 ###################
 
 This document describes hardware that has been tested and confirmed as
-compatible with |CLOSIA|. This list is not comprehensive and will continue to
+compatible with |CL-ATTR|. This list is not comprehensive and will continue to
 grow.
 
-.. list-table:: **Table 1. Clear Linux Compatible Hardware**
+.. list-table:: **Table 1. Compatible Hardware**
     :widths: 20, 20
     :header-rows: 1
 

--- a/source/clear-linux/reference/compatible-kernels.rst
+++ b/source/clear-linux/reference/compatible-kernels.rst
@@ -1,9 +1,9 @@
 .. _compatible-kernels:
 
-Compatible Clear Linux\* kernels
-################################
+Compatible kernels
+##################
 
-The |CLOSIA| provides the following Linux kernels with a respective bundle.
+The |CL-ATTR| provides the following Linux kernels with a respective bundle.
 This document describes the specific use cases these `bundles`_ serve
 and provides links to their source code.
 
@@ -44,10 +44,10 @@ The *kernel-kvm* bundle focuses on the Linux
 :abbr:`KVM (Kernel-based Virtual Machine)`. It is optimized for fast booting
 and performs best on Virtual Machines running on the Intel® architectures
 described on the :ref:`supported hardware list<system-requirements>`.
-Use this kernel when running |CL| as the guest OS on top of *qemu/kvm*. Use 
-this kernel with **cloud orchestrators** using *qemu/kvm* internally as 
-their **hypervisor**. This kernel can be used as a standalone |CL| VM, see 
-our :ref:`instructions on using KVM<kvm>` for more information. The 
+Use this kernel when running |CL| as the guest OS on top of *qemu/kvm*. Use
+this kernel with **cloud orchestrators** using *qemu/kvm* internally as
+their **hypervisor**. This kernel can be used as a standalone |CL| VM, see
+our :ref:`instructions on using KVM<kvm>` for more information. The
 optimization patches are found in our `Linux-KVM`_ GitHub repo.
 
 Kernel Hyper-V\*
@@ -58,7 +58,7 @@ Hyper-V. It is optimized for fast booting and performs best on Virtual
 Machines running on the Intel® architectures described on the
 :ref:`supported hardware list<system-requirements>`.
 Use this kernel when running |CL| as the guest OS of **Cloud Instances** in
-projects such as Microsoft `Azure`_\*. This kernel can be used in a 
+projects such as Microsoft `Azure`_\*. This kernel can be used in a
 standalone |CL| VM, see our :ref:`instructions on using Hyper-V<hyper-v>` for
 more information. The optimization patches are found in our `Linux-HyperV`_
 GitHub repo.

--- a/source/clear-linux/reference/how-to-clear-overview.rst
+++ b/source/clear-linux/reference/how-to-clear-overview.rst
@@ -6,7 +6,7 @@ How to Clear training overview
 The existing Linux\* ecosystem can be challenging to users because of long
 intervals between :abbr:`OS (operating system)` updates, which leads to large
 update downloads. Users can also be frustrated when managing complicated
-component dependencies. |CLOSIA| solves these problems by:
+component dependencies. |CL-ATTR| solves these problems by:
 
 *	Allowing you to update frequently, even multiple times per day
 *	Preventing you from combining incompatible components
@@ -31,7 +31,7 @@ overview of these |CL| mechanisms:
 *   Tools: `mixer-tools` software suite generates the update server content using |CL|
     official software update content, local bundle definitions, and local RPM files.
 
-The training helps you create a customized OS that is based on |CLOSIA|. The
+The training helps you create a customized OS that is based on |CL|. The
 training content is self-contained and hosted on GitHub. You need a clean
 |CL| installation and a functional network connection to complete the
 training. For convenience, the project includes the training files you need

--- a/source/clear-linux/reference/image-types.rst
+++ b/source/clear-linux/reference/image-types.rst
@@ -35,14 +35,14 @@ Table 2 lists the currently available images that are platform specific.
    * - Image Type
      - Description
 
-   * - installer.img 
-     - Preferred image of |CL| with interactive installer. 
+   * - installer.img
+     - Preferred image of |CL| with interactive installer.
 
    * - installer.iso
      - ISO of |CL| with interactive installer. Only for special cases where ISO image format is required (not for use with a USB key)
 
    * - live.img
-     - Image for live booting into memory, without requiring installaton. 
+     - Image for live booting into memory, without requiring installaton.
 
 .. list-table:: Table 2: Types of platform-specific |CL| images
    :widths: 15, 85
@@ -70,7 +70,7 @@ Table 2 lists the currently available images that are platform specific.
      - Virtual Hard Disk for use with Microsoft Hyper-V\* hypervisor. Includes `optimized kernel`_ for Hyper-V.
 
    * - kvm.img
-     - Image for booting in a simple VM with start_qemu.sh. Includes 
+     - Image for booting in a simple VM with start_qemu.sh. Includes
        `optimized kernel`_ for KVM.
 
    * - vmware.vmdk

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -3,11 +3,11 @@
 Reference
 #########
 
-This section provides additional information on the |CL| project and |CL|
+This section provides additional information on the |CL| project and
 features.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    compatible-hardware
    bundle-commands

--- a/source/clear-linux/reference/system-requirements.rst
+++ b/source/clear-linux/reference/system-requirements.rst
@@ -3,7 +3,7 @@
 Recommended minimum system requirements
 #######################################
 
-|CL-ATTR| can run on very minimal hardware. For example, it can run on a 
+|CL-ATTR| can run on very minimal hardware. For example, it can run on a
 system with a single core CPU, 128MB of memory, and 600MB of disk space.
 
 Different use cases and applications will require different configurations.
@@ -12,7 +12,7 @@ minimum requirements include:
 
 *  Processors:
 
-   |CL-ATTR| can run on any Intel® 64bit processors which support UEFI\* 
+   |CL-ATTR| can run on any Intel® 64bit processors which support UEFI\*
    and SSE\* v4.1 streaming SIMD\* instructions.
 
    The following processor families have been verified to run |CL|:


### PR DESCRIPTION
-Replace instances of CLOSIA substitution with CL-ATTR.
-Replace in-line use of Clear Linux with CL.
-Clean up white space.
-Limited clean up in collab section, in pref of future rework
-Set landing page toctree to use maxdepth 1

Signed-off-by: Kristal Dale <kristal.dale@intel.com>