### PR TITLE
Greengrass tutorial: Tutorial structure change, link updates, phrasing changes for clarity

### DIFF
--- a/source/clear-linux/tutorials/greengrass.rst
+++ b/source/clear-linux/tutorials/greengrass.rst
@@ -205,7 +205,7 @@ Creating and Packaging Lambda Functions
 
 
 #. In step 5, replace greengrassHelloWorld.py with the classification or object detection 
-   Greengrass sample from `Edge-Analytics`Faas`_:
+   Greengrass sample from `Edge-Analytics-Faas`_:
 
    * Classification: `greengrass_classification_sample.py`_
 

--- a/source/clear-linux/tutorials/greengrass.rst
+++ b/source/clear-linux/tutorials/greengrass.rst
@@ -5,14 +5,14 @@ Enable AWS Greengrass* and OpenVINO™ on |CL-ATTR|
 
 Hardware accelerated Function-as-a-Service (FaaS) enables cloud developers
 to deploy inference functionalities [1] on Intel® IoT edge devices with
-accelerators (Integrated GPU, Intel® FPGA, and Intel® Movidius™). These
+accelerators (CPU, Integrated GPU, Intel® FPGA, and Intel® Movidius™). These
 functions provide a great developer experience and seamless migration of
 visual analytics from cloud to edge in a secure manner using a containerized
 environment. Hardware-accelerated FaaS provides the best-in-class
 performance by accessing optimized deep learning libraries on Intel® IoT
 edge devices with accelerators.
 
-This tutorial shows how to:
+This tutorial will demonstrate how to:
 
 * Set up the Intel® edge device with |CL-ATTR|
 * Install the OpenVINO™ and AWS Greengrass* software stacks
@@ -31,13 +31,13 @@ The AWS Greengrass samples are located at the `Edge-Analytics-FaaS`_.
 
 We provide the following AWS Greengrass samples:
 
-* :file:`greengrass_classification_sample.py`
+* `greengrass_classification_sample.py`_
 
   This AWS Greengrass sample classifies a video stream using classification
   networks such as AlexNet and GoogLeNet and publishes top-10 results on AWS*
   IoT Cloud every second.
 
-* :file:`greengrass_object_detection_sample_ssd.py`
+* `greengrass_object_detection_sample_ssd.py`_
 
   This AWS Greengrass sample detects objects in a video stream and
   classifies them using single-shot multi-box detection (SSD) networks such
@@ -45,61 +45,6 @@ We provide the following AWS Greengrass samples:
   detection outputs such as class label, class confidence, and bounding box
   coordinates on AWS IoT Cloud every second.
 
-Converting Deep Learning Models
-*******************************
-
-Sample Models
-=============
-
-For classification, `download the BVLC Alexnet model`_ as an example.
-Any custom pre-trained classification models can be used with the
-classification sample.
-
-For object detection, the sample models optimized for Intel® edge platforms
-are present at :file:`/usr/share/openvino/models`. These models are provided
-as an example; however, any custom pre-trained SSD models can be used with
-the object detection sample.
-
-Running Model Optimizer
-=======================
-
-Follow these instructions for `converting deep learning models to Intermediate Representation using Model Optimizer`_. For example, use the
-following commands.
-
-For classification using BVLC Alexnet model:
-
-.. code-block:: bash
-
-   python3 mo.py --framework caffe --input_model <
-   model_location>/bvlc_alexnet.caffemodel --input_proto <
-   model_location>/deploy.prototxt --data_type <data_type> --output_dir <
-   output_dir> --input_shape [1,3,227,227]
-
-For object detection using SqueezeNetSSD-5Class model:
-
-.. code-block:: bash
-
-   python3 mo.py --framework caffe --input_model
-   SqueezeNetSSD-5Class.caffemodel --input_proto
-   SqueezeNetSSD-5Class.prototxt
-   --data_type <data_type> --output_dir <output_dir>
-
-In these examples:
-
-* ``<model_location>`` is :file:`/usr/share/openvino/models`
-
-* ``<data_type>`` is FP32 or FP16, depending on target device.
-
-* ``<output_dir>`` is the directory where the user wants to store the
-  Intermediate Representation (IR). IR contains .xml format corresponding
-  to the network structure and .bin format corresponding to weights. This
-  .xml file should be passed to <PARAM_MODEL_XML>.
-
-* In the BVLC Alexnet model, the prototxt defines the input shape with
-  batch size 10 by default. In order to use any other batch size, the
-  entire input shape needs to be provided as an argument to the model
-  optimizer. For example, to use batch size 1, you can provide
-  “--input_shape [1,3,227,227]”.
 
 Installing |CL| on the edge device
 **********************************
@@ -129,13 +74,6 @@ services to use (see Greengrass user below).
 
       usermod -G wheel -a <userid>
 
-#. Create the user and group account for the Greengrass daemon:
-
-   .. code-block:: console
-
-      useradd ggc_user
-      groupadd ggc_group
-
 #. Create a :file:`/etc/fstab` file.
 
    .. code-block:: bash
@@ -151,8 +89,8 @@ services to use (see Greengrass user below).
 Add required bundles
 ====================
 
-Use the ``swupd`` software updater utility to add the following bundles to
-enable the OpenVINO software stack:
+Use the ``swupd`` software updater utility to add the prerequisite bundles
+for the OpenVINO software stack:
 
 .. code-block:: bash
 
@@ -165,6 +103,67 @@ enable the OpenVINO software stack:
 The ``computer-vision-basic`` bundle will install the OpenVINO software,
 along with the edge device models needed.
 
+Converting Deep Learning Models
+===============================
+
+Locate Sample Models
+--------------------
+
+There are two types of provided models that can be used in conjunction with AWS Greengrass 
+for this tutorial: classification or object detection.
+
+To complete this tutorial using an image classification model,
+download the BVLC Alexnet model files `bvlc_alexnet.caffemodel`_ and `deploy.prototxt`_
+to the default model_location at :file:`/usr/share/openvino/models`.
+Any custom pre-trained classification models can be used with the
+classification sample.
+
+For object detection, the sample models optimized for Intel® edge platforms
+are included with the computer-vision-basic bundle installation at :file:`/usr/share/openvino/models`. 
+These models are provided as an example; however, you may also use a custom SSD model 
+with the Greengrass object detection sample.
+
+Running Model Optimizer
+-----------------------
+
+Follow these instructions for `converting deep learning models to Intermediate Representation using Model Optimizer`_. To optimize either of the afformentioned sample models, run one of the following commands.
+
+For classification using BVLC Alexnet model:
+
+.. code-block:: bash
+
+   python3 mo.py --framework caffe --input_model 
+   <model_location>/bvlc_alexnet.caffemodel --input_proto 
+   <model_location>/deploy.prototxt --data_type <data_type> --output_dir 
+   <output_dir> --input_shape [1,3,227,227]
+
+For object detection using SqueezeNetSSD-5Class model:
+
+.. code-block:: bash
+
+   python3 mo.py --framework caffe --input_model
+   <model_location>/'SqueezeNet 5-Class detection'/SqueezeNetSSD-5Class.caffemodel
+   --input_proto <model_location>/'SqueezeNet 5-Class detection'/SqueezeNetSSD-5Class.prototxt
+   --data_type <data_type> --output_dir <output_dir>
+
+In these examples:
+
+* ``<model_location>`` is :file:`/usr/share/openvino/models`
+
+* ``<data_type>`` is FP32 or FP16, depending on target device.
+
+* ``<output_dir>`` is the directory where the user wants to store the
+  Intermediate Representation (IR). IR contains .xml format corresponding
+  to the network structure and .bin format corresponding to weights. This
+  .xml file should be passed to <PARAM_MODEL_XML>.
+
+* In the BVLC Alexnet model, the prototxt defines the input shape with
+  batch size 10 by default. In order to use any other batch size, the
+  entire input shape needs to be provided as an argument to the model
+  optimizer. For example, to use batch size 1, you can provide
+  “--input_shape [1,3,227,227]”.
+
+
 Configuring an AWS Greengrass group
 ===================================
 
@@ -176,7 +175,9 @@ cloud and edge.
    `AWS Greengrass developer guide`_
 
 #. To install and configure AWS Greengrass core on edge platform, follow
-   the instructions at `Start AWS Greengrass on the Core Device`_.
+   the instructions at `Start AWS Greengrass on the Core Device`_. In 
+   step 8(b), download the x86_64 Ubuntu configuration of the AWS Greengrass
+   core software.
 
    .. note::
 
@@ -184,43 +185,40 @@ cloud and edge.
       of Module 1 of the `AWS Greengrass developer guide`_ because this is
       enabled already in |CL|.
 
-Creating and Packaging Lambda Functions
-=======================================
-
-#. Complete the tutorial at `Configure AWS Greengrass on AWS IoT`_ .
-
-   .. note::
-
-      This creates the tarball needed to create the AWS Greengrass
-      environment on the edge device.
-
-#. Assure to download both the security resources and the AWS Greengrass
+#. Be sure to download both the security resources and the AWS Greengrass
    core software.
 
    .. note::
 
       Security certificates are linked to your AWS* account.
 
-#. Replace greengrassHelloWorld.py with Greengrass samples:
 
-   * greengrass_classification_sample.py
+Creating and Packaging Lambda Functions
+=======================================
 
-   * greengrass_object_detection_sample_ssd.py
+#. Complete steps 1-4 of the tutorial at `Create and Package Lambda Function`_ . 
 
-#. Zip these files with extracted Greengrass SDK folders from the previous
+   .. note::
+
+      This creates the tarball needed to create the AWS Greengrass
+      environment on the edge device.
+
+
+#. In step 5, replace greengrassHelloWorld.py with the classification or object detection 
+   Greengrass sample from `Edge-Analytics`Faas`_:
+
+   * Classification: `greengrass_classification_sample.py`_
+
+   * Object Detection: `greengrass_object_detection_sample_ssd.py`_
+
+#. Zip the selected Greengrass sample with the extracted Greengrass SDK folders from the previous
    step into :file:`greengrass_sample_python_lambda.zip`.
 
    The zip should contain:
 
    * greengrasssdk
 
-   * greengrass sample
-
-   For the sample, choose one of these:
-
-   - greengrass_classification_sample.py
-
-   - greengrass_object_detection_sample_ssd.py
+   * greengrass classification or object detection sample
 
    For example:
 
@@ -229,11 +227,11 @@ Creating and Packaging Lambda Functions
       zip -r greengrass_lambda.zip greengrasssdk
       greengrass_object_detection_sample_ssd.py
 
-#. Follow steps 6-11 to `complete creating lambdas`_.
+#. Return to the AWS Documentation and follow steps 6-11 to `complete creating lambdas`_.
 
    .. note::
 
-      In the AWS documentation, step 9(a), while uploading the zip file,
+      In step 9(a) of the AWS documentation, while uploading the zip file,
       make sure to name the handler as below depending on the AWS Greengrass
       sample you are using:
 
@@ -266,12 +264,14 @@ configuring the lambda function for AWS Greengrass.
         - Value
       * - PARAM_MODEL_XML
         - <MODEL_DIR>/<IR.xml>, where <MODEL_DIR> is user specified and
-          contains IR.xml, the Intermediate Representation file from Intel® Model Optimizer
+          contains IR.xml, the Intermediate Representation file from Intel® Model Optimizer. 
+          For this tutorial, <MODEL_DIR> should be set to '/usr/share/openvino/models' 
+          or one of its subdirectories.
       * - PARAM_INPUT_SOURCE
         - <DATA_DIR>/input.webm to be specified by user. Holds both input and
            output data. For webcam, set PARAM_INPUT_SOURCE to ‘/dev/video0’
       * - PARAM_DEVICE
-        - For CPU, specify "CPU"
+        - "CPU"
       * - PARAM_CPU_EXTENSION_PATH
         - /usr/lib64/libcpu_extension.so
       * - PARAM_OUTPUT_DIRECTORY
@@ -377,7 +377,13 @@ References
 
 .. _Edge-Analytics-FaaS: https://github.com/intel/Edge-Analytics-FaaS/tree/master/AWS%20Greengrass
 
-.. _download the BVLC Alexnet model: https://github.com/BVLC/caffe/tree/master/models/bvlc_alexnet
+.. _bvlc_alexnet.caffemodel: http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel
+
+.. _deploy.prototxt: https://github.com/BVLC/caffe/blob/master/models/bvlc_alexnet/deploy.prototxt
+
+.. _greengrass_classification_sample.py: https://github.com/intel/Edge-Analytics-FaaS/blob/master/AWS%20Greengrass/greengrass_classification_sample.py
+
+.. _greengrass_object_detection_sample_ssd.py: https://github.com/intel/Edge-Analytics-FaaS/blob/master/AWS%20Greengrass/greengrass_object_detection_sample_ssd.py
 
 .. _converting deep learning models to Intermediate Representation using Model Optimizer: https://software.intel.com/en-us/articles/OpenVINO-ModelOptimizer
 
@@ -401,4 +407,4 @@ References
 
 .. _this link to add local resources and access privileges: https://docs.aws.amazon.com/greengrass/latest/developerguide/access-local-resources.html
 
-.. _Configure AWS Greengrass on AWS IoT: https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-config.html
+.. _Create and Package Lambda Function: https://docs.aws.amazon.com/greengrass/latest/developerguide/create-lambda.html


### PR DESCRIPTION
- Reordered Converting Deep Learning Models section to occur after CL install
- Removed instruction to add ggc_user and ggc_group as they are already present in CL
- Added links for Alexnet model and xml file
- Specified which configuration AWS Greengrass core software should be downloaded
- Fixed model directory path in model optimizer example for object detection
- Various other phrasing changes

Signed-off-by: Patrick Foley <patrick.foley@intel.com>