### PR TITLE
Remove unused CLOSIA substitution definition

### DIFF
--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -1,12 +1,10 @@
 .. |CL| replace:: Clear Linux OS
 
-.. |CLOSIA| replace:: Clear Linux* OS
-
 .. |CL-ATTR| replace:: Clear Linux* OS
 
 .. |CL-PRJ| replace:: Clear Linux* project
 
 .. |CC| replace:: Clear Containers
 
-.. |CAUTION-BACKUP-USB| replace:: 
+.. |CAUTION-BACKUP-USB| replace::
 	Burning an image formats the USB drive, thus destroying all existing content.  Backup your data before proceeding.


### PR DESCRIPTION
A previous PR removed the last use of the CLOSIA substitution. This PR removes the definition of the substitution entirely.

Signed-off-by: Kristal Dale <kristal.dale@intel.com>