### PR TITLE
Escapes http://address:port in bare-metal-install-beta; example, not link

### DIFF
--- a/source/clear-linux/get-started/bare-metal-install-beta/bare-metal-install-beta.rst
+++ b/source/clear-linux/get-started/bare-metal-install-beta/bare-metal-install-beta.rst
@@ -517,7 +517,7 @@ instruction.
       Figure 16: :guilabel:`Configure the network proxy`
 
 #. Enter the desired proxy address and port using conventional syntax,
-   such as: http://address:port.
+   such as: \http://address:port.
 
 #. Navigate to :guilabel:`Confirm` and select :kbd:`Enter`.
 


### PR DESCRIPTION
Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>