### PR TITLE
dlrs.rst: Updates DLRS tutorial

### DIFF
--- a/source/clear-linux/tutorials/dlrs.rst
+++ b/source/clear-linux/tutorials/dlrs.rst
@@ -85,13 +85,13 @@ TensorFlow.
 
    .. code-block:: bash
 
-      docker exec -t <docker_name> bash -c ‘git clone http://github.com/tensorflow/benchmarks -b cnn_tf_v1.12_compatible’
+      docker exec -t <docker_name> bash -c 'git clone http://github.com/tensorflow/benchmarks -b cnn_tf_v1.12_compatible'
 
 #. Next, execute the benchmark script to run the benchmark.
 
    .. code-block:: bash
 
-      docker exec -i <docker_name> bash -c ‘python benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --device=cpu --model=resnet50 --data_format=NHWC ’.
+      docker exec -i <docker_name> bash -c 'python benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --device=cpu --model=resnet50 --data_format=NHWC '.
 
 .. note::
 
@@ -164,16 +164,17 @@ following these instructions from their `quick start guide`_.
 .. code-block:: bash
 
    export KUBEFLOW_SRC=$HOME/kflow
-   export KUBEFLOW_TAG=”v0.3.2”
-   export KFAPP=”kflow_app”
-   export K8S_NAMESPACE=”kubeflow”
+   export KUBEFLOW_TAG="v0.4.1"
+   export KFAPP="kflow_app"
+   export K8S_NAMESPACE="kubeflow"
 
    mkdir ${KUBEFLOW_SRC}
    cd ${KUBEFLOW_SRC}
    ks init ${KFAPP}
    cd ${KFAPP}
    ks registry add kubeflow github.com/kubeflow/kubeflow/tree/${KUBEFLOW_TAG}/kubeflow
-   ks pkg install kubeflow/core
+   ks pkg install kubeflow/common
+   ks pkg install kubeflow/tf-training
 
 Now you have all the required kubeflow packages, and you can deploy the primary one for our purposes: tf-job-operator.
 
@@ -200,13 +201,23 @@ Run a TFJob
 
          ks pkg install dlrs-tfjob/dlrs-bench
 
+#. Export the image name you'd like to use for the deployment:
+
+   .. code-block:: bash
+
+      export DLRS_IMAGE=<docker_name>
+
+   .. note::
+
+      Replace <docker_name> with the image name you specified in previous steps.
+
 #. Next, generate Kubernetes manifests for the workloads and apply them to
    create and run them using these commands
 
    .. code-block:: bash
 
-      ks generate dlrs-resnet50 dlrsresnet50 --name=dlrsresnet50
-      ks generate dlrs-alexnet dlrsalexnet --name=dlrsalexnet
+      ks generate dlrs-resnet50 dlrsresnet50 --name=dlrsresnet50 --image=${DLRS_IMAGE}
+      ks generate dlrs-alexnet dlrsalexnet --name=dlrsalexnet --image=${DLRS_IMAGE}
       ks apply default -c dlrsresnet50
       ks apply default -c dlrsalexnet
 


### PR DESCRIPTION
The Kubeflow and DLRS projects made upstream changes that should be
reflected in the documentation.

This commit introduces the following changes:
    * Kubeflow version 0.3.2 -> 0.4.1
    * 'ks generate' now uses the --image flag so DLRS prototypes receive
      image names as parameters
    * Replacing ” with "
    * Installing the kubeflow/tf-training registry as it's required for
      deploying TFJobs
    * Replacing kubeflow/core with kubeflow/common

Signed-off-by: Daniela Plascencia <daniela.plascencia@linux.intel.com>