### PR TITLE
dlrs.rst: Updates DLRS tutorial

### DIFF
--- a/source/clear-linux/tutorials/dlrs.rst
+++ b/source/clear-linux/tutorials/dlrs.rst
@@ -141,7 +141,12 @@ cycle.
 ksonnet\*
 *********
 
-Kubeflow uses ksonnet* to manage deployments, so we need to install that before setting up Kubeflow. On |CL|, follow these steps:
+Kubeflow uses ksonnet* to manage deployments, so we need to install that before setting up Kubeflow.
+
+Since Clear Linux version 27550, the ksonnet was added to the bundle cloud-native-basic. But if using
+old versions (not recommended), please manually install the ksonnet as below.
+
+On |CL|, follow these steps:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The ksonnet was added to CL bundle cloud-native-basic, no need
manually install anymore.

Signed-off-by: Qi Zheng <qi.zheng@intel.com>