### PR TITLE
openssh-server: Brings back doc for sftp and X11 forwarding

### DIFF
--- a/source/clear-linux/reference/bundles/openssh-server.rst
+++ b/source/clear-linux/reference/bundles/openssh-server.rst
@@ -4,15 +4,33 @@ openssh-server
 ##############
 
 The **openssh-server** bundle provides the OpenSSH\* package needed to enable
-an SSH service in |CL-ATTR|. Remote users require a SSH service to be able to
-use an encrypted login shell.
+an SSH service in |CL-ATTR|. Remote users require an SSH service to be able
+to use an encrypted login shell.
 
 |CL| enables the `sshd.socket` unit, which will listen on port 22 by default
 and start the OpenSSH service as required. The first time OpenSSH starts, it
 generates the server SSH keys needed for the service.
 
+Prerequisites
+*************
+
+Assure the bundle :file:`openssh-server` is installed.
+
+To check it it's on your host, enter:
+
+.. code-block:: bash
+
+   sudo swupd bundle-list
+
+To add it, enter:
+
+.. code-block:: bash
+
+   sudo swupd bundle-add openssh-server
+
 Change default port
 *******************
+
 Perform the following steps to change the default listening port for the
 OpenSSH service:
 
@@ -22,10 +40,10 @@ OpenSSH service:
 
       sudo systemctl edit sshd.socket
 
-#. Add the `[Socket]` section and `ListenStream` option to the sshd.socket 
-   file as shown below. The first `ListenStream` entry removes the |CL| 
-   default listen port value. The second `ListenStream` entry sets the new 
-   default listen port value. In this example, we set the new default port 
+#. Add the `[Socket]` section and `ListenStream` option to the sshd.socket
+   file as shown below. The first `ListenStream` entry removes the |CL|
+   default listen port value. The second `ListenStream` entry sets the new
+   default listen port value. In this example, we set the new default port
    to 4200:
 
    .. code-block:: console
@@ -42,9 +60,9 @@ OpenSSH service:
    .. code-block:: bash
 
       cat /etc/systemd/system/sshd.socket.d/override.conf
-      
-   You should see the following output: 
-      
+
+   You should see the following output:
+
    .. code-block:: console
 
       [Socket]
@@ -63,7 +81,7 @@ OpenSSH service:
 
       sudo systemctl restart sshd.socket
 
-#. Confirm the the sshd.socket unit is listening on your new port: 
+#. Confirm the the sshd.socket unit is listening on your new port:
 
    .. code-block:: bash
 
@@ -71,7 +89,7 @@ OpenSSH service:
 
    .. note::
 
-      Output should show :guilable:`Active:` as `active(listening)`.
+      Output should show :guilabel:`Active:` as `active(listening)`.
 
 Enable SFTP
 ***********
@@ -100,7 +118,7 @@ the following configuration of the :abbr:`SSHD (SSH Daemon)` service file:
 
    .. code-block:: bash
 
-      systemctl daemon-reload
+      sudo systemctl daemon-reload
 
 Congratulations! The SFTP subsystem is enabled.
 
@@ -127,10 +145,10 @@ To enable root login via SSH, perform the following steps:
 Enable X11-forwarding
 *********************
 
-X11 forwarding allows you to securely run graphical applications (i.e., X clients)
-over the ssh conection. this will alow for remote gui apps without the need for full
-VNC/remotedesktop.
-To enable X11-forwarding via SSH, perform the following steps:
+X11 forwarding allows you to securely run graphical applications
+(i.e., X clients) over the ssh conection. This will alow for remote gui apps
+without the need for full VNC/remotedesktop. To enable X11-forwarding via
+SSH, perform the following steps:
 
 #. Create a *ssh* directory in :file:`/etc`, if it does not already exist.
 
@@ -143,7 +161,7 @@ To enable X11-forwarding via SSH, perform the following steps:
 
 #. Set the configuration variables.
 
-   .. code-block:: console
+   .. code-block:: bash
 
       AllowTcpForwarding yes
       X11UseLocalhost yes

--- a/source/clear-linux/reference/openssh-server.rst
+++ b/source/clear-linux/reference/openssh-server.rst
@@ -1,0 +1,151 @@
+.. _openssh-server:
+
+openssh-server
+##############
+
+The **openssh-server** bundle provides the OpenSSH\* package needed to enable
+an SSH service in |CL-ATTR|. Remote users require a SSH service to be able to
+use an encrypted login shell.
+
+|CL| enables the `sshd.socket` unit, which will listen on port 22 by default
+and start the OpenSSH service as required. The first time OpenSSH starts, it
+generates the server SSH keys needed for the service.
+
+Change default port
+*******************
+Perform the following steps to change the default listening port for the
+OpenSSH service:
+
+#. Open the sshd.socket file:
+
+   .. code-block:: bash
+
+      sudo systemctl edit sshd.socket
+
+#. Add the `[Socket]` section and `ListenStream` option to the sshd.socket 
+   file as shown below. The first `ListenStream` entry removes the |CL| 
+   default listen port value. The second `ListenStream` entry sets the new 
+   default listen port value. In this example, we set the new default port 
+   to 4200:
+
+   .. code-block:: console
+
+      [Socket]
+      ListenStream=
+      ListenStream=4200
+
+
+   Make sure to include a new line after the last line of text in the sshd.socket file.
+
+#. Verify your changes:
+
+   .. code-block:: bash
+
+      cat /etc/systemd/system/sshd.socket.d/override.conf
+      
+   You should see the following output: 
+      
+   .. code-block:: console
+
+      [Socket]
+      ListenStream=
+      ListenStream=4200
+
+#. Reload the systemd daemon configurations:
+
+   .. code-block:: bash
+
+      sudo systemctl daemon-reload
+
+#. Restart the sshd.socket unit:
+
+   .. code-block:: bash
+
+      sudo systemctl restart sshd.socket
+
+#. Confirm the the sshd.socket unit is listening on your new port: 
+
+   .. code-block:: bash
+
+      sudo systemctl status sshd.socket
+
+   .. note::
+
+      Output should show :guilable:`Active:` as `active(listening)`.
+
+Enable SFTP
+***********
+
+|CL| *disables* the :abbr:`SFTP (SSH File Transfer Protocol)` subsystem by
+default due to security considerations. To enable the SFTP subsystem, perform
+the following configuration of the :abbr:`SSHD (SSH Daemon)` service file:
+
+#. Create a systemd drop-in directory for the SSHD service:
+
+   .. code-block:: bash
+
+      sudo mkdir -p /etc/systemd/system/sshd@.service.d
+
+#. Create the following file:
+   :file:`/etc/systemd/system/sshd@.service.d/sftp.conf`
+
+#. Add the OPTIONS environment variable to the sftp.conf file.
+
+   .. code-block:: console
+
+      [Service]
+      Environment="OPTIONS=-o Subsystem=\"sftp /usr/libexec/sftp-server\""
+
+#. Reload systemd configuration:
+
+   .. code-block:: bash
+
+      systemctl daemon-reload
+
+Congratulations! The SFTP subsystem is enabled.
+
+Enable root login
+*****************
+
+To enable root login via SSH, perform the following steps:
+
+#. Create a *ssh* directory in :file:`/etc`, if it does not already exist.
+
+   .. code-block:: bash
+
+      mkdir /etc/ssh
+
+#. Create the following file, if it does not already exist:
+   :file:`/etc/ssh/sshd_config`
+
+#. Set the configuration variable in /etc/ssh/sshd_config
+
+   .. code-block:: console
+
+      PermitRootLogin yes
+
+Enable X11-forwarding
+*********************
+
+X11 forwarding allows you to securely run graphical applications (i.e., X clients)
+over the ssh conection. this will alow for remote gui apps without the need for full
+VNC/remotedesktop.
+To enable X11-forwarding via SSH, perform the following steps:
+
+#. Create a *ssh* directory in :file:`/etc`, if it does not already exist.
+
+   .. code-block:: bash
+
+      mkdir /etc/ssh
+
+#. Create the following file, if it does not already exist:
+   :file:`/etc/ssh/sshd_config`
+
+#. Set the configuration variables.
+
+   .. code-block:: console
+
+      AllowTcpForwarding yes
+      X11UseLocalhost yes
+      X11DisplayOffset 10
+      X11Forwarding yes

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -17,3 +17,4 @@ features.
    compatible-kernels
    system-requirements
    image-types
+   openssh-server

--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -12,9 +12,9 @@ features.
    compatible-hardware
    bundle-commands
    bundles/bundles
+   bundles/openssh-server
    how-to-clear-overview
    collaboration/collaboration
    compatible-kernels
    system-requirements
    image-types
-   openssh-server


### PR DESCRIPTION
Back by popular demand....
This continues @puneetse's and @odwdinc 's work from Oct. 2018.  
I validated content; added Prereq section; added `sudo` where needed for consistency. Please validate. 
