### PR TITLE
kvm: Simplify step to install vncviewer

### DIFF
--- a/source/clear-linux/get-started/virtual-machine-install/kvm.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/kvm.rst
@@ -135,7 +135,7 @@ To add :abbr:`GDM (GNOME Display Manager)` to the |CL| VM, follow these steps:
 
      .. code-block:: bash
 
-        swupd bundle-add desktop-apps-extras 
+        swupd bundle-add tigervnc
 
    * On Ubuntu\* 16.04 LTS Desktop:
 


### PR DESCRIPTION
swupd bundle-add tigervnc is enough to install a vncviewer (5MB vs 125 MB of desktop-apps-extras)