### PR TITLE
Adds missing `_` leading space before file name; root cause image failure

### DIFF
--- a/source/clear-linux/guides/maintenance/architect-lifecycle.rst
+++ b/source/clear-linux/guides/maintenance/architect-lifecycle.rst
@@ -1,4 +1,4 @@
-.. architect-lifecycle:
+.. _architect-lifecycle:
 
 Architect the life-cycle of |CL-ATTR|
 #####################################


### PR DESCRIPTION
Rushing this PR out. FYI only. 1 char fix. 

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>