### PR TITLE
Remove older unused openssh-server ref from toctree.

### DIFF
--- a/source/clear-linux/reference/reference.rst
+++ b/source/clear-linux/reference/reference.rst
@@ -18,4 +18,4 @@ features.
    compatible-kernels
    system-requirements
    image-types
-   openssh-server
+   


### PR DESCRIPTION
Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>