### PR TITLE
Update URLs to use CDN and fix documentation build warning

### DIFF
--- a/source/_themes/clearlinux/header.html
+++ b/source/_themes/clearlinux/header.html
@@ -16,7 +16,7 @@
             <div class="region region-header">
               <div id="block-system-main-menu" class="block block-system block-menu">
                 <ul class="menu">
-                  <li class="first leaf"><a href="https://download.clearlinux.org" title="Downloads" target="_blank">Downloads</a></li>
+                  <li class="first leaf"><a href="https://cdn.download.clearlinux.org" title="Downloads" target="_blank">Downloads</a></li>
                   <li class="collapsed"><a href="/features" title="Features">Features</a></li>
                   <li class="collapsed"><a href="/documentation" title="Documentation" class="active">Documentation</a></li>
                 </ul>

--- a/source/clear-linux/get-started/bare-metal-install-beta/bare-metal-install-beta.rst
+++ b/source/clear-linux/get-started/bare-metal-install-beta/bare-metal-install-beta.rst
@@ -859,6 +859,6 @@ Next steps
 
 :ref:`enable-user-space`
 
-.. _Navigate to the image directory: https://download.clearlinux.org/image/
+.. _Navigate to the image directory: https://cdn.download.clearlinux.org/image/
 .. _Autoproxy: https://clearlinux.org/features/autoproxy
 .. _telemetry: https://clearlinux.org/features/telemetry

--- a/source/clear-linux/get-started/bare-metal-install/bare-metal-install.rst
+++ b/source/clear-linux/get-started/bare-metal-install/bare-metal-install.rst
@@ -34,7 +34,7 @@ Optionally, you can use this command:
 
 .. code-block:: bash
 
-   curl -O https://download.clearlinux.org/image/$(curl https://download.clearlinux.org/image/latest-images | grep "installer")
+   curl -O https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images | grep "installer")
 
 #. Follow your OS instructions to create a bootable USB drive.
 

--- a/source/clear-linux/get-started/compatibility-check.rst
+++ b/source/clear-linux/get-started/compatibility-check.rst
@@ -19,7 +19,7 @@ below.
 
    .. code-block:: console
 
-      curl -O https://download.clearlinux.org/current/clear-linux-check-config.sh
+      curl -O https://cdn.download.clearlinux.org/current/clear-linux-check-config.sh
 
 #. Make the script executable.
 
@@ -58,4 +58,4 @@ below.
       SUCCESS: Carry-less Multiplication extensions (pclmulqdq)
       SUCCESS: EFI Firmware
 
-.. _clear-linux-check-config.sh: https://download.clearlinux.org/current/clear-linux-check-config.sh
+.. _clear-linux-check-config.sh: https://cdn.download.clearlinux.org/current/clear-linux-check-config.sh

--- a/source/clear-linux/get-started/live-image.rst
+++ b/source/clear-linux/get-started/live-image.rst
@@ -29,7 +29,7 @@ Boot the |CL| live image
    
 .. _create and enable user space: https://clearlinux.org/documentation/clear-linux/guides/maintenance/enable-user-space 
 
-.. _`image`: https://download.clearlinux.org/image
+.. _`image`: https://cdn.download.clearlinux.org/image
 
 .. _`Intel® Virtualization Technology (Intel® VT)`: http://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html
 

--- a/source/clear-linux/get-started/virtual-machine-install/hyper-v.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/hyper-v.rst
@@ -57,4 +57,4 @@ Your virtual machine running |CL| is ready!
 .. _Windows Server Virtualization: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/
 .. _Microsoft documentation: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v
 .. _Create A Virtual Network documentation: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/connect-to-network
-.. _downloads: https://download.clearlinux.org/image/
+.. _downloads: https://cdn.download.clearlinux.org/image/

--- a/source/clear-linux/get-started/virtual-machine-install/kvm.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/kvm.rst
@@ -50,12 +50,12 @@ Download and launch the virtual machine
 ***************************************
 
 #. Download the latest pre-built |CL| KVM image file from
-   the `image <https://download.clearlinux.org/image/>`_ directory. Look for
+   the `image <https://cdn.download.clearlinux.org/image/>`_ directory. Look for
    ``clear-<version>-kvm.img.xz``.  You can also use this command: 
 
    .. code-block:: bash
 
-      curl -O https://download.clearlinux.org/image/$(curl https://download.clearlinux.org/image/latest-images | grep '[0-9]'-kvm)
+      curl -O https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images | grep '[0-9]'-kvm)
 
 #. Uncompress the downloaded image:
 
@@ -64,7 +64,7 @@ Download and launch the virtual machine
       unxz clear-<version>-kvm.img.xz
 
 #. Download the `OVMF file`_ file that provides UEFI support for
-   virtual machines from the `image <https://download.clearlinux.org/image/>`_ directory.
+   virtual machines from the `image <https://cdn.download.clearlinux.org/image/>`_ directory.
 
 #. Copy :file:`OVMF.fd` to the working directory, as shown below.
 
@@ -79,13 +79,13 @@ Download and launch the virtual machine
       For non-Clear Linux hosts, the preferred approach is to download it from https://cdn.download.clearlinux.org/image/OVMF.fd
 
 #. Download the sample `QEMU-KVM launcher`_ script from the
-   `image <https://download.clearlinux.org/image/>`_ directory.  This script
+   `image <https://cdn.download.clearlinux.org/image/>`_ directory.  This script
    will launch the |CL| VM and provide console interaction within the same
    terminal emulator window.
    
    .. code-block:: bash
       
-      curl -O https://download.clearlinux.org/image/start_qemu.sh
+      curl -O https://cdn.download.clearlinux.org/image/start_qemu.sh
    
 
 #. Make the script executable:
@@ -243,5 +243,5 @@ To add :abbr:`GDM (GNOME Display Manager)` to the |CL| VM, follow these steps:
 
 .. _Intel® Virtualization Technology: https://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html
 .. _Intel®Virtualization Technology for Directed I/O: https://software.intel.com/en-us/articles/intel-virtualization-technology-for-directed-io-vt-d-enhancing-intel-platforms-for-efficient-virtualization-of-io-devices
-.. _QEMU-KVM launcher: https://download.clearlinux.org/image/start_qemu.sh
-.. _OVMF file: https://download.clearlinux.org/image/OVMF.fd
+.. _QEMU-KVM launcher: https://cdn.download.clearlinux.org/image/start_qemu.sh
+.. _OVMF file: https://cdn.download.clearlinux.org/image/OVMF.fd

--- a/source/clear-linux/get-started/virtual-machine-install/virtualbox-cl-installer.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/virtualbox-cl-installer.rst
@@ -41,7 +41,7 @@ The appropriate |CL| installer image needs to be downloaded and extracted.
 
    .. code-block:: bash
 
-      curl -O https://download.clearlinux.org/image/$(curl https://download.clearlinux.org/image/latest-images | grep installer.iso)
+      curl -O https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images | grep installer.iso)
 
 #. Validate the integrity of the downloaded image by checking the file hash 
    and signatures. Refer to the document on :ref:`validate-signatures` for 

--- a/source/clear-linux/get-started/virtual-machine-install/virtualbox.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/virtualbox.rst
@@ -52,7 +52,7 @@ be used to created a |VB| virtual disk image that can be used with a
 
    .. code-block:: bash
 
-      curl -O https://download.clearlinux.org/image/$(curl https://download.clearlinux.org/image/latest-images | grep live.img)
+      curl -O https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images | grep live.img)
 
 #. Validate the integrity of the downloaded image by checking the file hash 
    and signatures. Refer to the document on :ref:`validate-signatures` for 

--- a/source/clear-linux/get-started/virtual-machine-install/vmw-player-preconf.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/vmw-player-preconf.rst
@@ -64,7 +64,7 @@ this command:
 
 .. code-block:: bash
 
-   curl -O https://download.clearlinux.org/image/$(curl https://download.clearlinux.org/image/latest-images | grep vmware)
+   curl -O https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images | grep vmware)
 
 Visit :ref:`image-types` for additional information about all available |CL| images.
 
@@ -306,8 +306,8 @@ For other guides on using the VMWare Player and ESXi, see:
 .. _VMware ESXi: https://www.vmware.com/products/esxi-and-esx.html
 .. _VMware Workstation 14 Player: https://www.vmware.com/products/workstation-player.html
 .. _VMware Workstation Player guide: https://docs.vmware.com/en/VMware-Workstation-Player/index.html
-.. _latest: https://download.clearlinux.org/image/
-.. _image: https://download.clearlinux.org/image
+.. _latest: https://cdn.download.clearlinux.org/image/
+.. _image: https://cdn.download.clearlinux.org/image
 
 
 

--- a/source/clear-linux/get-started/virtual-machine-install/vmw-player.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/vmw-player.rst
@@ -297,6 +297,6 @@ For other guides on using the VMWare Player and ESXi, see:
 .. _VMware Workstation Player guide:
    https://docs.vmware.com/en/VMware-Workstation-Player/index.html
 
-.. _latest: https://download.clearlinux.org/image/
+.. _latest: https://cdn.download.clearlinux.org/image/
 
-.. _image: https://download.clearlinux.org/image
+.. _image: https://cdn.download.clearlinux.org/image

--- a/source/clear-linux/get-started/virtual-machine-install/vmware-esxi-install-cl.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/vmware-esxi-install-cl.rst
@@ -291,4 +291,4 @@ Related topics
 
 .. _VMware ESXi: https://www.vmware.com/products/esxi-and-esx.html
 .. _VMware Workstation Player: https://www.vmware.com/products/workstation-player.html
-.. _image: https://download.clearlinux.org/image
+.. _image: https://cdn.download.clearlinux.org/image

--- a/source/clear-linux/get-started/virtual-machine-install/vmware-esxi-preconfigured-cl-image.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/vmware-esxi-preconfigured-cl-image.rst
@@ -36,7 +36,7 @@ this command:
 
 .. code-block:: bash
 
-   curl -O https://download.clearlinux.org/image/$(curl https://download.clearlinux.org/image/latest-images | grep vmware)
+   curl -O https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images | grep vmware)
 
 Visit :ref:`image-types` for additional information about all available |CL| images.
 
@@ -290,4 +290,4 @@ Related topics
 .. _VMware documentation on Enable the Secure Shell (SSH): https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.html.hostclient.doc/GUID-B649CB74-832F-467B-B6A4-8BA67AD5C1F0.html
 .. _VMware documentation on General ESXi Security Recommendations: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.security.doc/GUID-B39474AF-6778-499A-B8AB-E973BE6D4899.html
 .. _VMware Workstation Player: https://www.vmware.com/products/workstation-player.html
-.. _image: https://download.clearlinux.org/image
+.. _image: https://cdn.download.clearlinux.org/image

--- a/source/clear-linux/guides/deploy-at-scale.rst
+++ b/source/clear-linux/guides/deploy-at-scale.rst
@@ -269,7 +269,7 @@ challenges your monitoring systems, and business continuity plans.
 
 .. _`mixin process`: https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixin
 .. _`mixer process`: https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixer
-.. _`downloads page`: https://download.clearlinux.org/image/
+.. _`downloads page`: https://cdn.download.clearlinux.org/image/
 .. _`containers page`: https://clearlinux.org/containers
 .. _`systemd journal-remote service`: https://www.freedesktop.org/software/systemd/man/systemd-journal-remote.service.html
 .. _`native telemetry solution`: https://clearlinux.org/features/telemetry

--- a/source/clear-linux/guides/maintenance/increase-virtual-disk-size.rst
+++ b/source/clear-linux/guides/maintenance/increase-virtual-disk-size.rst
@@ -166,4 +166,4 @@ Resize the filesytem
 Congratulations! You have resized the disk, partition, and filesystem. At
 this point, the increase in disk capacity is usable.
 
-.. _releases: https://download.clearlinux.org/releases/
+.. _releases: https://cdn.download.clearlinux.org/releases/

--- a/source/clear-linux/guides/maintenance/kernel-development.rst
+++ b/source/clear-linux/guides/maintenance/kernel-development.rst
@@ -430,7 +430,7 @@ Related topics
 
 .. _distribution on GitHub: https://github.com/clearlinux/distribution/issues/new/choose
 
-.. _source RPM files: https://download.clearlinux.org/current/source/SRPMS/
+.. _source RPM files: https://cdn.download.clearlinux.org/current/source/SRPMS/
 
 .. _Quilt: http://savannah.nongnu.org/projects/quilt
 

--- a/source/clear-linux/guides/maintenance/swupd-guide.rst
+++ b/source/clear-linux/guides/maintenance/swupd-guide.rst
@@ -49,7 +49,7 @@ Current OS version and update server info:
 .. code-block:: console
 
    Installed version: 23330
-   Version URL:       https://download.clearlinux.org/update/
+   Version URL:       https://cdn.download.clearlinux.org/update/
    Content URL:       https://cdn.download.clearlinux.org/update/
 
 Enable or disable automatic updates

--- a/source/clear-linux/guides/maintenance/validate-signatures.rst
+++ b/source/clear-linux/guides/maintenance/validate-signatures.rst
@@ -26,11 +26,11 @@ used for illustrative purposes. You may use any image of |CL| you choose.
    .. code-block:: console
 
       # Image
-      curl -O https://download.clearlinux.org/current/clear-$(curl https://download.clearlinux.org/latest)-installer.img.xz
+      curl -O https://cdn.download.clearlinux.org/current/clear-$(curl https://cdn.download.clearlinux.org/latest)-installer.img.xz
       # Signature of SHA512 sum of image
-      curl -O https://download.clearlinux.org/current/clear-$(curl https://download.clearlinux.org/latest)-installer.img.xz-SHA512SUMS.sig
+      curl -O https://cdn.download.clearlinux.org/current/clear-$(curl https://cdn.download.clearlinux.org/latest)-installer.img.xz-SHA512SUMS.sig
       # Certificate
-      curl -O https://download.clearlinux.org/releases/$(curl https://download.clearlinux.org/latest)/clear/ClearLinuxRoot.pem
+      curl -O https://cdn.download.clearlinux.org/releases/$(curl https://cdn.download.clearlinux.org/latest)/clear/ClearLinuxRoot.pem
 
 #. Generate the SHA256 sum of the |CL| certificate.
 
@@ -49,7 +49,7 @@ used for illustrative purposes. You may use any image of |CL| you choose.
 
    .. code-block:: console
 
-      sha512sum clear-$(curl https://download.clearlinux.org/latest)-installer.img.xz > sha512sum.out
+      sha512sum clear-$(curl https://cdn.download.clearlinux.org/latest)-installer.img.xz > sha512sum.out
 
 #. Ensure the signature of the SHA512 sum of the image was created using the
    |CL| certificate. This validates the image is trusted and it has not
@@ -57,7 +57,7 @@ used for illustrative purposes. You may use any image of |CL| you choose.
 
    .. code-block:: console
 
-      openssl smime -verify -purpose any -in clear-$(curl https://download.clearlinux.org/latest)-installer.img.xz-SHA512SUMS.sig -inform der -content sha512sum.out -CAfile ClearLinuxRoot.pem
+      openssl smime -verify -purpose any -in clear-$(curl https://cdn.download.clearlinux.org/latest)-installer.img.xz-SHA512SUMS.sig -inform der -content sha512sum.out -CAfile ClearLinuxRoot.pem
 
    .. note::
 
@@ -83,11 +83,11 @@ these steps manually when performing a ``swupd update``.
    .. code-block:: console
 
       # MoM
-      curl -O https://download.clearlinux.org/update/$(curl https://download.clearlinux.org/latest)/Manifest.MoM
+      curl -O https://cdn.download.clearlinux.org/update/$(curl https://cdn.download.clearlinux.org/latest)/Manifest.MoM
       # Signature of MoM
-      curl -O https://download.clearlinux.org/update/$(curl https://download.clearlinux.org/latest)/Manifest.MoM.sig
+      curl -O https://cdn.download.clearlinux.org/update/$(curl https://cdn.download.clearlinux.org/latest)/Manifest.MoM.sig
       # Swupd certificate
-      curl -O https://download.clearlinux.org/releases/$(curl https://download.clearlinux.org/latest)/clear/Swupd_Root.pem
+      curl -O https://cdn.download.clearlinux.org/releases/$(curl https://cdn.download.clearlinux.org/latest)/clear/Swupd_Root.pem
 
 #. Generate the SHA256 sum of the Swupd certificate.
 

--- a/source/clear-linux/guides/network/dpdk.rst
+++ b/source/clear-linux/guides/network/dpdk.rst
@@ -262,7 +262,7 @@ machines control the NICs on the host.
 
    .. code-block:: bash
 
-      sudo curl -O https://download.clearlinux.org/image/start_qemu.sh
+      sudo curl -O https://cdn.download.clearlinux.org/image/start_qemu.sh
 
 #. Download a bare-metal image of |CL| and rename it as :file:`clear.img`.
 
@@ -338,7 +338,7 @@ machines control the NICs on the host.
 #. Run the :file:`start_qemu.sh` script.
 
 
-.. _13330: https://download.clearlinux.org/releases/13330/
+.. _13330: https://cdn.download.clearlinux.org/releases/13330/
 .. _DPDK project: http://dpdk.org
 .. _dpdk.org NICs: http://dpdk.org/doc/nics
 .. _pktgen tar package: http://dpdk.org/browse/apps/pktgen-dpdk/refs

--- a/source/clear-linux/guides/network/ipxe-install.rst
+++ b/source/clear-linux/guides/network/ipxe-install.rst
@@ -103,8 +103,8 @@ To set up |CL| manually, perform the steps below.
 
       sudo mkdir -p $ipxe_root
       sudo curl -o /tmp/clear-pxe.tar.xz \
-        https://download.clearlinux.org/current/clear-$(curl \
-        https://download.clearlinux.org/latest)-pxe.tar.xz
+        https://cdn.download.clearlinux.org/current/clear-$(curl \
+        https://cdn.download.clearlinux.org/latest)-pxe.tar.xz
       sudo tar -xJf /tmp/clear-pxe.tar.xz -C $ipxe_root
       sudo ln -sf $(ls $ipxe_root | grep 'org.clearlinux.*') $ipxe_root/linux
 

--- a/source/clear-linux/reference/image-types.rst
+++ b/source/clear-linux/reference/image-types.rst
@@ -76,6 +76,6 @@ Table 2 lists the currently available images that are platform specific.
    * - vmware.vmdk
      - Virtual Machine Disk for VMware\* platforms inclduing Player, Workstation, and ESXi.
 
-.. _images: https://download.clearlinux.org/image
+.. _images: https://cdn.download.clearlinux.org/image
 .. _`optimized kernel`: https://clearlinux.org/documentation/clear-linux/reference/compatible-kernels
 

--- a/source/clear-linux/tutorials/multi-boot/multi-boot.rst
+++ b/source/clear-linux/tutorials/multi-boot/multi-boot.rst
@@ -55,7 +55,7 @@ installation of the tested operating systems.
 .. csv-table:: Table 1: OS specific installation information
    :header: # , OS, Version, Partition Size [#]_, Swap Size [#]_, EFI Partition Size [#]_, Download Link
 
-   1,Clear Linux,16140,50 GB,8 GB,1 GB,https://download.clearlinux.org/releases/16140/clear/
+   1,Clear Linux,16140,50 GB,8 GB,1 GB,https://cdn.download.clearlinux.org/releases/16140/clear/
    2,Windows,Server 2016,50 GB,N/A,Shared with #1,https://www.microsoft.com/en-us/cloud-platform/windows-server
    3,Red Hat\*,Server 7.4 Beta,45 GB,Shared with #1,Shared with #1,https://access.redhat.com/downloads/
    4,SUSE\*,Server 12 SP2,45 GB,Shared with #1,Shared with #1,https://www.suse.com/download-linux/


### PR DESCRIPTION
There are two commits in this PR:
1. Fix a documentation build warning (see below [1])
2. Update the URLs pointing at https://download.clearlinux.org to use the CDN (i.e. https://cdn.download.clearlinux.org). This will greatly improves the user experience of those not in the US.

[1] Documentation build warning:
```
$ make html
make -C source html
make[1]: Entering directory '/home/gvancuts/work/clear-linux-documentation/source'
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.7.5
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] clear-linux/reference/reference                                                                                                                                                          
/home/gvancuts/work/clear-linux-documentation/source/clear-linux/reference/reference.rst:9: WARNING: toctree contains reference to nonexisting document 'clear-linux/reference/openssh-server'
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/gvancuts/work/clear-linux-documentation/source/clear-linux/reference/bundles/openssh-server.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] sitemap                                                                                                                                                                                   
generating indices... genindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
make[1]: Leaving directory '/home/gvancuts/work/clear-linux-documentation/source'
```