### PR TITLE
Bootable USB

### DIFF
--- a/source/clear-linux/get-started/bootable-usb/bootable-usb.rst
+++ b/source/clear-linux/get-started/bootable-usb/bootable-usb.rst
@@ -78,7 +78,7 @@ Burn the |CL| image onto a USB drive
       ├─sda8   8:8    0    30G  0 part /
       └─sda6   8:6    0   7.9G  0 part [SWAP]
 
-#. You must unmount a USB drive before you can burn an image onto it. Note that
+#. You must unmount a USB drive before burning an image onto it. Note that
    some Linux distros automatically mount a USB drive when it is plugged in.
    Unmount a USB drive with the :command:`umount` command followed by the device
    identifier/partition. For example:
@@ -94,6 +94,10 @@ Burn the |CL| image onto a USB drive
    .. code-block:: bash
 
       dd if=./clear-[version number]-[image type] of=<your USB device> bs=4M status=progress && sync
+
+.. caution::
+
+   |CAUTION-UNMOUNT-USB-PARTITIONS|
 
 .. _bootable-usb-mac:
 

--- a/source/clear-linux/get-started/bootable-usb/bootable-usb.rst
+++ b/source/clear-linux/get-started/bootable-usb/bootable-usb.rst
@@ -93,7 +93,7 @@ Burn the |CL| image onto a USB drive
 
    .. code-block:: bash
 
-      dd if=./clear-[version number]-[image type] of=<your USB device> bs=4M status=progress && sync
+      dd if=./clear-[version number]-[image type] of=<your USB device> oflag=sync bs=4M status=progress
 
 .. caution::
 

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -9,3 +9,8 @@
 .. |CAUTION-BACKUP-USB| replace::
 	Burning an image formats the USB drive, and will destroy all pre-existing
 	content.  Back up your data before proceeding.
+
+.. |CAUTION-UNMOUNT-USB-PARTITIONS| replace::
+	Not fully unmounting the USB drive before burning an image could cause
+	file system checksum errors in it. If this happens, burn the image again
+	ensuring all the USB drive partitions are unmounted first.


### PR DESCRIPTION
Update the 'Create a bootable USB drive' manual with an additional caution to prevent users from errors that may occur when the USB drive partitions are not properly unmounted before burning an image, and allow them to correct the issues if they occur.

Also, update the example burning command to improve its performance and progress output.