### PR TITLE
Update to parse-link-check.py

### DIFF
--- a/source/scripts/_python/linkcheck/link-whitelist.txt
+++ b/source/scripts/_python/linkcheck/link-whitelist.txt
@@ -5,15 +5,8 @@ https://software.intel.com/en-us/articles/intel-virtualization-technology-for-di
 https://software.intel.com/en-us/articles/intel-virtualization-technology-for-directed-io-vt-d-enhancing-intel-platforms-for-efficient-virtualization-of-io-devices
 https://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html
 https://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html
-https://github.com/clearlinux/common#build-rpms-for-a-package
 https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html
 http://ark.intel.com
-https://clearlinux.org/documentation/clear-linux/concepts/bundles-about#related-concepts
 https://software.intel.com/en-us/articles/OpenVINO-ModelOptimizer
-https://github.com/kata-containers/documentation/blob/master/Upgrading.md#maintenance-warning
-https://github.com/clearcontainers/runtime#configuration
-https://github.com/kata-containers/runtime#configuration
-https://kubernetes.io/docs/user-journeys/users/application-developer/foundational/#section-3
-https://kubernetes.io/docs/user-journeys/users/application-developer/foundational/#section-2
 https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html
 http://www.intel.com/content/www/us/en/nuc/nuc-kit-nuc6i5syh.html

--- a/source/scripts/_python/linkcheck/parse-link-check.py
+++ b/source/scripts/_python/linkcheck/parse-link-check.py
@@ -21,6 +21,14 @@
 #        appear in the same directory as output.txt
 #     2. Error code 255 if unexpected broken links are found
 #
+# Purpose:
+#     This script supplements the built-in link checking of 
+#     sphinx-build. In practice, sphinx-build link checking
+#     will produce a variety of false negatives. This script,
+#     using the white list will skip known false negatives and
+#     anchors, providing an HTML digest of suspected actual
+#     broken links. 
+#
 #***********************************************************
 
 

--- a/source/scripts/_python/linkcheck/parse-link-check.py
+++ b/source/scripts/_python/linkcheck/parse-link-check.py
@@ -52,8 +52,10 @@ with open (fileNamePath) as f:
 
 numBrokenLinks = 0
 numWhiteListMatches = 0
+numAnchors = 0
 newLines = ["<!DOCTYPE html><html><head><style>body {font-family: sans-serif;}</style></head><body>"]
 whiteListLines = []
+anchorLines = []
 
 for line in lines:
     if "[broken]" in line:
@@ -63,12 +65,19 @@ for line in lines:
         if link in whitelist:
             whiteListLines.append("<b>" + strings[0] + "</b>\n<blockquote><a href=\"" + link + "\">[whitelist] " + link + "</a></blockquote>\n")
             numWhiteListMatches += 1
-        else:
+        elif "Anchor '" in line:
+            anchorLines.append("<b>" + strings[0] + "</b>\n<blockquote><a href=\"" + link + "\">[anchor] " + link + "</a></blockquote>\n")
+            numAnchors += 1
+        else: 
             newLines.append("<b>" + strings[0] + "</b>\n<blockquote><a href=\"" + link + "\">[broken] " + link + "</a></blockquote>\n")
             numBrokenLinks += 1
 
 newLines.insert(0,"<h1>" + str(numBrokenLinks + numWhiteListMatches) + " broken links found in Sphinx link check</h1>\n")
 newLines.insert(1,"<h2>" + str(numBrokenLinks) + " unmatched broken links</h2>\n")
+newLines.append("<h2>" + str(numAnchors) + " links did not find anchors</h2>\n")
+for line in anchorLines:
+    newLines.append(line)
+
 newLines.append("<h2>" + str(numWhiteListMatches) + " links matched whitelist</h2>\n")
 for line in whiteListLines:
 	newLines.append(line)

--- a/source/scripts/_python/linkcheck/parse-link-check.py
+++ b/source/scripts/_python/linkcheck/parse-link-check.py
@@ -5,11 +5,15 @@
 # parse-link-check.py
 # 
 # Arguments:
-#     1. path to input file 
+#     1. working directory: path to directory containing output
+#        of sphinx-build linkcheck (output.txt). Output of this
+#        script (broken_links.html) will also be saved in this
+#        location.
 #
 # External file dependencies:
 #     1. output.txt - the output of sphinx-build
-#     2. link-whitelist.txt - broken links that should be ignored
+#     2. link-whitelist.txt - broken links that should be ignored. 
+#        This file should be in the same location as this script.
 #
 # Output:
 #     1. broken_links.html - provides count of broken and whitelist 

--- a/source/scripts/_python/linkcheck/parse-link-check.py
+++ b/source/scripts/_python/linkcheck/parse-link-check.py
@@ -25,9 +25,9 @@
 #     This script supplements the built-in link checking of 
 #     sphinx-build. In practice, sphinx-build link checking
 #     will produce a variety of false negatives. This script,
-#     using the white list will skip known false negatives and
+#     using the white list, will skip known false negatives and
 #     anchors, providing an HTML digest of suspected actual
-#     broken links. 
+#     broken links if there are any.
 #
 #***********************************************************
 


### PR DESCRIPTION
Updated parse-link-check.py script to ignore anchors. 

Motivation:

1. Anchors in .rst files in GitHub are considered broken by the tester though they resolve correctly when manually clicking through on the browser.
2. Broken anchors should not block the site from being built.
3. There are now 3 categories in broken_links.html
   1. unmatched broken links
   2. broken links on the white list
   3. broken anchors