### PR TITLE
CVE patch. Update requirements.txt to Jinja2-2.11.dev0.

### DIFF
--- a/source/scripts/_python/requirements.txt
+++ b/source/scripts/_python/requirements.txt
@@ -1,2 +1,2 @@
-Jinja2==2.10
+Jinja2==2.11.dev0
 GitPython==2.1.11


### PR DESCRIPTION
- Address CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-8341

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>