### PR TITLE
kata: removes configuration step /etc/systemd/system/docker.service.d/50-runtime .conf

### DIFF
--- a/source/clear-linux/tutorials/docker/docker.rst
+++ b/source/clear-linux/tutorials/docker/docker.rst
@@ -98,6 +98,8 @@ More information on installing and using  the *kata-runtime* may be found at :re
    need to continue reading. The following sections are provided here for
    sake of completeness.
 
+.. _additional-docker-configuration:
+
 Additional Docker configuration
 *******************************
 
@@ -124,6 +126,9 @@ exist by default.
          {
             "storage-driver": "devicemapper"
          }
+
+#. As noted in warning message on devicemapper, "usage of loopback devices
+   is strongly discouraged for production use". Therefore, we recommend following this link to `Configure direct lvm mode for production`_ for improved efficiency and ease of scalability.
 
 #. Once you've made any required changes, be sure to restart the
    Docker daemon through systemd manager by running this command:
@@ -228,3 +233,5 @@ Related topics
 .. _Docker documentation on swarm key concepts: https://docs.docker.com/engine/swarm/key-concepts/
 
 .. _Docker documentation on creating a swarm: https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/
+
+.. _Configure direct lvm mode for production: https://docs.docker.com/storage/storagedriver/device-mapper-driver/

--- a/source/clear-linux/tutorials/docker/docker.rst
+++ b/source/clear-linux/tutorials/docker/docker.rst
@@ -119,16 +119,22 @@ exist by default.
       Refer to the `Docker documentation on daemon configuration`_ for the
       full list of available configuration options and examples.
 
-      A minimal configuration would be:
+#. For production systems, we follow Docker's recommendation to use the
+   `OverlayFS storage driver`_ `overlay2`, shown below:
 
-      .. code-block:: json
+   .. code-block:: json
 
-         {
-            "storage-driver": "devicemapper"
-         }
+      {
+         "storage-driver": "overlay2"
+      }
 
-#. As noted in warning message on devicemapper, "usage of loopback devices
-   is strongly discouraged for production use". Therefore, we recommend following this link to `Configure direct lvm mode for production`_ for improved efficiency and ease of scalability.
+   .. note::
+
+      A testing version is found in `Docker Device Mapper storage driver`_.
+      If using this storage driver, a warning message may appear: "usage of
+      loopback devices is strongly discouraged for production use".
+
+#. Save and close :file:`daemon.json`.
 
 #. Once you've made any required changes, be sure to restart the
    Docker daemon through systemd manager by running this command:
@@ -235,3 +241,7 @@ Related topics
 .. _Docker documentation on creating a swarm: https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/
 
 .. _Configure direct lvm mode for production: https://docs.docker.com/storage/storagedriver/device-mapper-driver/
+
+.. _OverlayFS storage driver: https://docs.docker.com/storage/storagedriver/overlayfs-driver/
+
+.. _Docker Device Mapper storage driver: https://docs.docker.com/storage/storagedriver/device-mapper-driver/

--- a/source/clear-linux/tutorials/kata.rst
+++ b/source/clear-linux/tutorials/kata.rst
@@ -110,7 +110,7 @@ To do so, enter:
 .. code-block:: bash
 
    sudo mkdir -p /etc/systemd/system/docker.service.d/
-   cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/51-runtime.conf
+   cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/50-runtime.conf
    [Service]
    Environment="DOCKER_DEFAULT_RUNTIME=--default-runtime kata-runtime"
    EOF

--- a/source/clear-linux/tutorials/kata.rst
+++ b/source/clear-linux/tutorials/kata.rst
@@ -99,7 +99,7 @@ To check which runtime your system uses, enter:
 
 .. note::
 
-   To change the Docker devicemapper settings for production use, see
+   To change the Docker storage driver, see
    :ref:`additional-docker-configuration`.
 
 For some |CL| versions before 27000, you may need to manually

--- a/source/clear-linux/tutorials/kata.rst
+++ b/source/clear-linux/tutorials/kata.rst
@@ -90,36 +90,27 @@ it automatically uses the runtime supported by the system.
 Troubleshooting
 ===============
 
-To check which runtime your system uses, enter:
+- To change the Docker storage driver, see
+  :ref:`additional-docker-configuration`.
 
-.. code-block:: bash
+- For some |CL| versions before 27000, you may need to manually
+  configure Docker\* to use Kata Containers by default.
 
-   sudo docker info | grep runtime
+  To do so, enter:
 
+  .. code-block:: bash
 
-.. note::
+     sudo mkdir -p /etc/systemd/system/docker.service.d/
+     cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/50-runtime.conf
+     [Service]
+     Environment="DOCKER_DEFAULT_RUNTIME=--default-runtime kata-runtime"
+     EOF
 
-   To change the Docker storage driver, see
-   :ref:`additional-docker-configuration`.
+- To check the version of |CL| on your system, enter:
 
-For some |CL| versions before 27000, you may need to manually
-configure Docker\* to use Kata Containers by default.
+  .. code-block:: bash
 
-To do so, enter:
-
-.. code-block:: bash
-
-   sudo mkdir -p /etc/systemd/system/docker.service.d/
-   cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/50-runtime.conf
-   [Service]
-   Environment="DOCKER_DEFAULT_RUNTIME=--default-runtime kata-runtime"
-   EOF
-
-To check the version of |CL| on your system, enter:
-
-.. code-block:: bash
-
-   sudo swupd verify
+     sudo swupd verify
 
 
 .. _Kata Containers: https://katacontainers.io/

--- a/source/clear-linux/tutorials/kata.rst
+++ b/source/clear-linux/tutorials/kata.rst
@@ -27,24 +27,14 @@ Before you install any new packages, update |CL| with the following command:
 Install Kata Containers
 ***********************
 
-Kata Containers is included in the :file:`containers-virt` bundle. To install the
-framework, enter the following command:
+Kata Containers is included in the :file:`containers-virt` bundle.
+To install the framework, enter the following command:
 
 .. code-block:: bash
 
    sudo swupd bundle-add containers-virt
 
-Configure Docker\* to use Kata Containers by default.
-
-.. code-block:: bash
-
-   sudo mkdir -p /etc/systemd/system/docker.service.d/
-   cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/51-runtime.conf
-   [Service]
-   Environment="DOCKER_DEFAULT_RUNTIME=--default-runtime kata-runtime"
-   EOF
-
-Restart the Docker and Kata Containers systemd services.
+Restart the Docker\* and Kata Containers systemd services.
 
 .. code-block:: bash
 
@@ -97,10 +87,39 @@ environment:
 You do not need to manually configure the runtime for Docker, because
 it automatically uses the runtime supported by the system.
 
-Check which runtime your system is using with the command:
+Troubleshooting
+===============
+
+To check which runtime your system uses, enter:
 
 .. code-block:: bash
 
    sudo docker info | grep runtime
+
+
+.. note::
+
+   To change the Docker devicemapper settings for production use, see
+   :ref:`additional-docker-configuration`.
+
+For some |CL| versions before 27000, you may need to manually
+configure Docker\* to use Kata Containers by default.
+
+To do so, enter:
+
+.. code-block:: bash
+
+   sudo mkdir -p /etc/systemd/system/docker.service.d/
+   cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/51-runtime.conf
+   [Service]
+   Environment="DOCKER_DEFAULT_RUNTIME=--default-runtime kata-runtime"
+   EOF
+
+To check the version of |CL| on your system, enter:
+
+.. code-block:: bash
+
+   sudo swupd verify
+
 
 .. _Kata Containers: https://katacontainers.io/


### PR DESCRIPTION
- 50-runtime.conf file automatically created on CL builds > 27000
- Adds Troubleshooting, and adds prev manual conf option
- Closes #453

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>