### PR TITLE
Update command to verify CL root partition in fix-broken-install.rst 

### DIFF
--- a/source/clear-linux/guides/maintenance/fix-broken-install.rst
+++ b/source/clear-linux/guides/maintenance/fix-broken-install.rst
@@ -42,18 +42,19 @@ Mount root partition, verify, and fix
 
       We'll use `/dev/sda3/` as the root partition example.
 
-   #. Next, mount it.
+   #. Next, mount the partition to the `/mnt` folder.
 
       .. code-block:: bash
 
          sudo mount /dev/sda3 /mnt
 
-#. Verify that you mounted the correct root partition by checking the list
-   of bundles that you installed on it.
+#. Verify that you mounted the correct root partition by checking for some 
+   files commonly found on |CL| systems.
 
    .. code-block:: bash
 
-      ls /usr/share/clear/bundles
+      cat /mnt/usr/lib/os-release
+      ls /mnt/usr/share/clear/bundles
 
 #. Next, run swupd to fix any issues on the target system.
 


### PR DESCRIPTION
This PR:

- Fixes the command in fix-broken-install.rst to verify the mounted root partition is a Clear Linux partition. The current command is incorrect because it checks a file from the temporarily booted live OS, not the mounted partition to repair. 

- Minor elaboration on mounting step for clarity. 