### PR TITLE
Fixed incorrectly formed link that was resulting in 404

### DIFF
--- a/source/clear-linux/tutorials/nvidia.rst
+++ b/source/clear-linux/tutorials/nvidia.rst
@@ -31,8 +31,7 @@ Install the LTS kernel and DKMS
 *******************************
 
 The Long Term Support (LTS) kernel variant is most likely to remain
-compatible with NVIDIA drivers. The `Dynamic Kernel Module System (DKMS)
-<kernel-modules-dkms>`_ allows the NVIDIA kernel modules to be automatically
+compatible with NVIDIA drivers. The :ref:`Dynamic Kernel Module System (DKMS) <kernel-modules-dkms>` allows the NVIDIA kernel modules to be automatically
 integrated when kernel updates occur in |CL|. Install both using the
 instructions below:
 


### PR DESCRIPTION
Found it during link checking. The link is formatted as a URL reference but needed to use :ref: for internal link.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>