### PR TITLE
Repairs links broken be removing https://clearlinux.org/containers

### DIFF
--- a/source/clear-linux/guides/deploy-at-scale.rst
+++ b/source/clear-linux/guides/deploy-at-scale.rst
@@ -270,7 +270,7 @@ challenges your monitoring systems, and business continuity plans.
 .. _`mixin process`: https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixin
 .. _`mixer process`: https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixer
 .. _`downloads page`: https://clearlinux.org/downloads/
-.. _`containers page`: https://clearlinux.org/news-blogs/intel-clear-containers-now-part-kata-containers
+.. _`containers page`: https://clearlinux.org/downloads/containers
 .. _`systemd journal-remote service`: https://www.freedesktop.org/software/systemd/man/systemd-journal-remote.service.html
 .. _`native telemetry solution`: https://clearlinux.org/features/telemetry
 .. _`micro-config-drive`: https://github.com/clearlinux/micro-config-drive

--- a/source/clear-linux/guides/deploy-at-scale.rst
+++ b/source/clear-linux/guides/deploy-at-scale.rst
@@ -270,7 +270,7 @@ challenges your monitoring systems, and business continuity plans.
 .. _`mixin process`: https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixin
 .. _`mixer process`: https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixer
 .. _`downloads page`: https://clearlinux.org/downloads/
-.. _`containers page`: https://clearlinux.org/containers
+.. _`containers page`: https://clearlinux.org/news-blogs/intel-clear-containers-now-part-kata-containers
 .. _`systemd journal-remote service`: https://www.freedesktop.org/software/systemd/man/systemd-journal-remote.service.html
 .. _`native telemetry solution`: https://clearlinux.org/features/telemetry
 .. _`micro-config-drive`: https://github.com/clearlinux/micro-config-drive

--- a/source/clear-linux/guides/tooling/swupd-guide.rst
+++ b/source/clear-linux/guides/tooling/swupd-guide.rst
@@ -346,7 +346,7 @@ Related topics
 
 .. _source documentation: https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst
 
-.. _Kata Containers: https://clearlinux.org/news-blogs/intel-clear-containers-now-part-kata-containers
+.. _Kata Containers: https://clearlinux.org/downloads/containers
 
 .. _one bundle: https://github.com/clearlinux/clr-bundles/blob/master/bundles/containers-virt
 

--- a/source/clear-linux/guides/tooling/swupd-guide.rst
+++ b/source/clear-linux/guides/tooling/swupd-guide.rst
@@ -346,7 +346,7 @@ Related topics
 
 .. _source documentation: https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst
 
-.. _Kata Containers: https://clearlinux.org/containers
+.. _Kata Containers: https://clearlinux.org/news-blogs/intel-clear-containers-now-part-kata-containers
 
 .. _one bundle: https://github.com/clearlinux/clr-bundles/blob/master/bundles/containers-virt
 


### PR DESCRIPTION
Fixed broken links to now non-existant page: https://clearlinux.org/containers

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>