### PR TITLE
Fix license in autospec example.

### DIFF
--- a/source/clear-linux/guides/tooling/autospec.rst
+++ b/source/clear-linux/guides/tooling/autospec.rst
@@ -242,7 +242,7 @@ and dependencies in order for autospec to complete a successful build.
 
    .. code-block:: bash
 
-      echo "Intel" > opae-sdk.license
+      echo "MIT" > opae-sdk.license
 
 #. Run autospec again:
 

--- a/source/clear-linux/guides/tooling/autospec.rst
+++ b/source/clear-linux/guides/tooling/autospec.rst
@@ -242,7 +242,7 @@ and dependencies in order for autospec to complete a successful build.
 
    .. code-block:: bash
 
-      echo "MIT" > opae-sdk.license
+      echo "BSD-3-Clause MIT" > opae-sdk.license
 
 #. Run autospec again:
 

--- a/source/clear-linux/guides/tooling/autospec.rst
+++ b/source/clear-linux/guides/tooling/autospec.rst
@@ -242,7 +242,7 @@ and dependencies in order for autospec to complete a successful build.
 
    .. code-block:: bash
 
-      echo "Intel Corporation" > opae-sdk.license
+      echo "Intel" > opae-sdk.license
 
 #. Run autospec again:
 

--- a/source/clear-linux/guides/tooling/autospec.rst
+++ b/source/clear-linux/guides/tooling/autospec.rst
@@ -238,7 +238,7 @@ and dependencies in order for autospec to complete a successful build.
 
       cd packages/opae-sdk
 
-#. Add a license:
+#. Add a valid license identifier from the `SPDX License List <https://spdx.org/licenses/>`_:
 
    .. code-block:: bash
 

--- a/source/clear-linux/guides/tooling/autospec.rst
+++ b/source/clear-linux/guides/tooling/autospec.rst
@@ -238,7 +238,10 @@ and dependencies in order for autospec to complete a successful build.
 
       cd packages/opae-sdk
 
-#. Add a valid license identifier from the `SPDX License List <https://spdx.org/licenses/>`_:
+#. Add one or more valid license identifier from the
+   `SPDX License List <https://spdx.org/licenses/>`_.
+   In the example below, two different licenses are appropriate based on the 
+   opae-sdk project licensing:
 
    .. code-block:: bash
 


### PR DESCRIPTION
The correct identifier for the Intel Open Source license is just "Intel" not "Intel Corporation"