### PR TITLE
Add statement to clarify enable/disable default status of client

### DIFF
--- a/source/clear-linux/concepts/telemetry-about.rst
+++ b/source/clear-linux/concepts/telemetry-about.rst
@@ -24,6 +24,10 @@ for debugging purposes. You can use **libtelemetry** in your code to create cust
 telemetry records. You can also use **telem-record-gen** in script files or call
 it from another program.
 
+.. note::
+
+   The |CL| telemetry client is disabled by default until you decide to enable it.  Telemetry is an **opt-in** solution and can be easily enabled or disabled.
+
 Architecture
 ************
 

--- a/source/clear-linux/guides/telemetrics/telem-guide.rst
+++ b/source/clear-linux/guides/telemetrics/telem-guide.rst
@@ -3,7 +3,7 @@
 Telemetrics
 ###########
 
-Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis. Note that the telemetry client is disabled by default, this is an opt-in solution.
+Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis. Note that the telemetry client is disabled by default, this is an **opt-in** solution.
 
 .. contents::
    :local:
@@ -24,7 +24,7 @@ Telemetrics is a combination word made from:
 
 |CL| telemetry is fully customizable and can be used during software development for debugging purposes. You can use the  libtelemetry library in your code to create custom telemetry records. You can also use the telem-record-gen utility in script files for light touch record creation where instrumenting code files doesn't make sense.
 
-The |CL| telemetrics solution is is opt-in on the client side.  By default the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
+The |CL| telemetrics solution is an opt-in on the client side.  By default the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
 
 Architecture
 ============

--- a/source/clear-linux/guides/telemetrics/telem-guide.rst
+++ b/source/clear-linux/guides/telemetrics/telem-guide.rst
@@ -7,7 +7,7 @@ Telemetrics in |CL-ATTR| is a client and server solution used to collect data fr
 
 .. important::
 
-   Telemetry in |CL| is **opt-in**. The telemetry client will **not** be active or send any data until you explicitly enable it.  
+   Telemetry in |CL| is **opt-in**. The telemetry client is **not**  active and sends **no** data until you explicitly enable it.
 
 .. note::
 
@@ -33,7 +33,7 @@ Telemetrics is a combination word made from:
 
 |CL| telemetry is fully customizable and can be used during software development for debugging purposes. You can use the  libtelemetry library in your code to create custom telemetry records. You can also use the telem-record-gen utility in script files for light touch record creation where instrumenting code files doesn't make sense.
 
-The |CL| telemetrics solution is an **opt-in** choice on the client side.  By default the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
+The |CL| telemetrics solution is an **opt-in** choice on the client side.  By default, the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
 
 Architecture
 ============

--- a/source/clear-linux/guides/telemetrics/telem-guide.rst
+++ b/source/clear-linux/guides/telemetrics/telem-guide.rst
@@ -3,7 +3,11 @@
 Telemetrics
 ###########
 
-Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis. Note that the telemetry client is disabled by default, this is an **opt-in** solution.
+Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis.
+
+.. important::
+
+   Telemetry in |CL| is **opt-in**. The telemetry client will **not** be active or send any data until you explicitly enable it.  
 
 .. note::
 

--- a/source/clear-linux/guides/telemetrics/telem-guide.rst
+++ b/source/clear-linux/guides/telemetrics/telem-guide.rst
@@ -5,6 +5,11 @@ Telemetrics
 
 Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis. Note that the telemetry client is disabled by default, this is an **opt-in** solution.
 
+.. note::
+
+   The telemetry functionality adheres to `Intel privacy policies`_ regarding the collection and use of :abbr:`PII (Personally Identifiable Information)` and is open source.
+   Specifically, no intentionally identifiable information about the user or system owner is collected.
+
 .. contents::
    :local:
    :depth: 1
@@ -24,7 +29,7 @@ Telemetrics is a combination word made from:
 
 |CL| telemetry is fully customizable and can be used during software development for debugging purposes. You can use the  libtelemetry library in your code to create custom telemetry records. You can also use the telem-record-gen utility in script files for light touch record creation where instrumenting code files doesn't make sense.
 
-The |CL| telemetrics solution is an opt-in on the client side.  By default the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
+The |CL| telemetrics solution is an **opt-in** choice on the client side.  By default the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
 
 Architecture
 ============
@@ -59,10 +64,7 @@ The telemetry backend provides the server-side component of the telemetrics solu
 
    The default telemetry backend server is hosted by the Intel |CL| development team and is not viewable outside the Intel firewall. To collect your own records, you must set up your own telemetry backend server.
 
-.. note::
 
-   The telemetry functionality adheres to `Intel privacy policies`_ regarding the collection and use of :abbr:`PII (Personally Identifiable Information)` and is open source.
-   Specifically, no intentionally identifiable information about the user or system owner is collected.
 
 How To Use
 **********

--- a/source/clear-linux/guides/telemetrics/telem-guide.rst
+++ b/source/clear-linux/guides/telemetrics/telem-guide.rst
@@ -3,7 +3,7 @@
 Telemetrics
 ###########
 
-Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis.
+Telemetrics in |CL-ATTR| is a client and server solution used to collect data from running |CL| systems to help quickly identify and fix bugs in the OS.  Both client and server are customizable, and an API is available on the client side for instrumenting your code for debug and analysis. Note that the telemetry client is disabled by default, this is an opt-in solution.
 
 .. contents::
    :local:
@@ -23,6 +23,8 @@ Telemetrics is a combination word made from:
 |CL| telemetry reports system-level debug/crash information using specialized probes. The probes monitor system tasks such as swupd, kernel oops, machine error checks, and the BIOS error report table for unhandled hardware failures. Telemetry enables real-time issue reporting to allow system developers to quickly focus on an issue and monitor corrective actions.
 
 |CL| telemetry is fully customizable and can be used during software development for debugging purposes. You can use the  libtelemetry library in your code to create custom telemetry records. You can also use the telem-record-gen utility in script files for light touch record creation where instrumenting code files doesn't make sense.
+
+The |CL| telemetrics solution is is opt-in on the client side.  By default the telemetry client is disabled until you choose to enable it. Enabling the client is covered in this guide.
 
 Architecture
 ============


### PR DESCRIPTION
Responding to comment in forums -- this will clarify that the telemetry client is disabled until the user chooses to enable it, whether at install or later. 