### PR TITLE
Remove non-production image types

### DIFF
--- a/source/clear-linux/reference/image-types.rst
+++ b/source/clear-linux/reference/image-types.rst
@@ -63,9 +63,6 @@ Table 2 lists the currently available images that are platform specific.
    * - cloudguest.img
      - Image with generic cloud guest virtual machine (VM) requirements installed.
 
-   * - container-host-kvm.img
-     - Image for use by Clear Containers runtime. Includes `optimized kernel`_ for Clear Containers.
-
    * - gce.tar
      - Image with the Google Compute Engine (GCE) specific kernel.
 


### PR DESCRIPTION
container-host-kvm.img is considered developmental and should not be
shown in documentation.  Want to keep list of image types in
documentation oriented toward production.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>