### PR TITLE
Fix minor syntax on nvidia.rst

### DIFF
--- a/source/clear-linux/tutorials/nvidia.rst
+++ b/source/clear-linux/tutorials/nvidia.rst
@@ -281,7 +281,7 @@ driver restored by:
       sudo rm /etc/modprobe.d/disable-nouveau.conf
 
 
-# Remove the :file`xorg.conf.d` file that adds a search path for X modules.
+#. Remove the :file`xorg.conf.d` file that adds a search path for X modules.
 
    .. code:: bash
 


### PR DESCRIPTION
One character change (.) that was missed causing the numbered list not to render. 