### PR TITLE
Tooling link clean up

### DIFF
--- a/source/clear-linux/guides/tooling/autospec.rst
+++ b/source/clear-linux/guides/tooling/autospec.rst
@@ -382,7 +382,7 @@ To test an autospec-created package inside a VM:
       make install
 
    The code that makes this possible can be viewed by searching for the
-   *install:*  target in the `Makefile.common file on GitHub`_.
+   *install:*  target in the `Makefile.common`_ file on GitHub.
 
 #. Return to the :file:`~/clearlinux` directory and start the |CL| VM:
 
@@ -427,7 +427,7 @@ To test an autospec created package directly on the |CL| development system:
       make install-local
 
    The code that makes this possible can be viewed by searching for the
-   *install-local:*  target in the `Makefile.common file on GitHub`_.
+   *install-local:*  target in the `Makefile.common`_  file on GitHub.
 
 #. Check that the software is installed as expected and perform any relevant
    tests.
@@ -503,8 +503,7 @@ Related topics
 
 * :ref:`Mixer tool <mixer>`
 
-.. _user-setup script: https://github.com/clearlinux/common/blob/master/user-setup.sh
-.. _`Makefile.common file on GitHub`: https://github.com/clearlinux/common/blob/master/Makefile.common
+.. _`Makefile.common`: https://github.com/clearlinux/common/blob/master/Makefile.common
 .. _autospec README: https://github.com/clearlinux/autospec
 .. _control files: https://github.com/clearlinux/autospec#control-files
 .. _mock wiki: https://github.com/rpm-software-management/mock/wiki

--- a/source/clear-linux/guides/tooling/debug.rst
+++ b/source/clear-linux/guides/tooling/debug.rst
@@ -1,6 +1,6 @@
 .. _debug:
 
-Debug System
+Debug system
 ############
 
 |CL-ATTR| introduces a novel approach to system software debugging using

--- a/source/clear-linux/guides/tooling/ister.rst
+++ b/source/clear-linux/guides/tooling/ister.rst
@@ -3,7 +3,7 @@
 ister.py image builder
 ######################
 
-The `ister.py tool`_ is a template-based installer used by |CL-ATTR| to produce
+The `ister.py`_ tool is a template-based installer used by |CL-ATTR| to produce
 images for each release. The same ister tool is available for use in |CL| to
 create custom images based on an upstream image.
 
@@ -49,14 +49,15 @@ image. Here are some examples:
 Follow these steps to recreate an upstream image based on the image's JSON
 configuration file:
 
-#. Install the :command:`os-installer` bundle. Refer to `Install a bundle`_ for
-   more details.
+#. Install the :command:`os-installer` bundle. Refer to :ref:`swupd-guide` for
+   more information on installing bundles.
 
-#. Download the `ister.py tool`_ and grant it sudo privileges.
+#. Download the `ister.py`_ tool and grant it sudo privileges.
 
-#. Download the JSON configuration file for the desired image:
+#. Download the JSON configuration file for the desired image (located in
+   :file:`config/image/`):
 
-   * `Configuration files for the current release`_
+   * `Current release`_
    * `Previous releases`_ (only after March 2017)
 
    For a previous release, navigate to `Previous releases`_, select the version
@@ -87,7 +88,6 @@ Related topics
 * :ref:`mixer`
 * :ref:`bulk-provision`
 
-.. _ister.py tool: https://github.com/bryteise/ister
-.. _Configuration files for the current release: https://cdn.download.clearlinux.org/current/config/image/
+.. _ister.py: https://github.com/bryteise/ister
+.. _Current release: https://cdn.download.clearlinux.org/current/
 .. _Previous releases: https://cdn.download.clearlinux.org/releases/
-.. _Install a bundle: https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#adding-a-bundle

--- a/source/clear-linux/guides/tooling/mixer.rst
+++ b/source/clear-linux/guides/tooling/mixer.rst
@@ -50,7 +50,7 @@ Prerequisites
 * :command:`mixer` bundle
 
   Add the mixer tool with the :command:`mixer` bundle. Refer to
-  `Install a bundle`_ for more details.
+  :ref:`swupd-guide` for more information on installing bundles.
 
 * Docker\* container
 
@@ -109,7 +109,7 @@ the setup before you create a mix.
    View the `mixer.init man page`_ for more information on mixer
    initialization.
 
-   View the list of `suitable versions`_ from which to mix.
+   View the list of suitable `releases`_ from which to mix.
 
 #. Edit builder.conf.
 
@@ -840,5 +840,4 @@ Related topics
 .. _mixer.init man page: https://github.com/clearlinux/mixer-tools/blob/master/docs/mixer.init.1.rst
 .. _mixer.bundle man page: https://github.com/clearlinux/mixer-tools/blob/master/docs/mixer.bundle.1.rst
 .. _mixer.build man page: https://github.com/clearlinux/mixer-tools/blob/master/docs/mixer.build.1.rst
-.. _suitable versions: https://github.com/clearlinux/clr-bundles/releases
-.. _Install a bundle: https://clearlinux.org/documentation/clear-linux/guides/maintenance/swupd-guide#adding-a-bundle
+.. _releases: https://github.com/clearlinux/clr-bundles/releases

--- a/source/clear-linux/guides/tooling/swupd-guide.rst
+++ b/source/clear-linux/guides/tooling/swupd-guide.rst
@@ -196,7 +196,7 @@ kernel instance and runs on its own :abbr:`VM (Virtual Machine)` for
 improved security.
 
 |CL| makes it very easy to install, since you only need to add
-`one bundle`_ to use `Kata Containers`_: `containers-virt`, despite a
+one bundle to use `Kata Containers`_: `containers-virt`_, despite a
 number of dependencies.  Also, check out our tutorial: :ref:`kata`.
 
 #. Find the correct bundle.
@@ -326,7 +326,7 @@ swupd --help
 man swupd
    Opens the :command:`swupd` man page.
 
-Refer to :command:`swupd` `source documentation`_ on GitHub for more details.
+Refer to `swupd source documentation`_ on GitHub for more details.
 
 Related topics
 **************
@@ -335,11 +335,11 @@ Related topics
 * :ref:`mixer`
 * :ref:`bundles`
 
-.. _source documentation: https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst
+.. _swupd source documentation: https://github.com/clearlinux/swupd-client/blob/master/docs/swupd.1.rst
 
 .. _Kata Containers: https://clearlinux.org/downloads/containers
 
-.. _one bundle: https://github.com/clearlinux/clr-bundles/blob/master/bundles/containers-virt
+.. _containers-virt: https://github.com/clearlinux/clr-bundles/blob/master/bundles/containers-virt
 
 .. _Bundle Definition Files: https://github.com/clearlinux/clr-bundles
 


### PR DESCRIPTION
Basic link clean up in advance of translation of content.

- Removed unused links
- Updated links defined as named refs to use simple text e.g. name of linked content
instead of narrative text.
- Minor text edits to accomodate minor changes to name ref links.

Signed-off-by: Kristal Dale <kristal.dale@intel.com>