### PR TITLE
Maintenance Guides: Basic link clean up in advance of translation of content

### DIFF
--- a/source/clear-linux/guides/maintenance/architect-lifecycle.rst
+++ b/source/clear-linux/guides/maintenance/architect-lifecycle.rst
@@ -38,7 +38,8 @@ Description
 
 Coordinated infrastructure is deployed to automate the life-cycle
 of your |CL| derivative. We divide deployment of this infrastucture in two
-parts: *Content Workflow*; and *Release Workflow*, shown in Figure 1. Distro Factory manages the *Release Workflow* while capturing the requirements for
+parts: *Content Workflow*; and *Release Workflow*, shown in Figure 1. Distro
+Factory manages the *Release Workflow* while capturing the requirements for
 maintaining a long-term release cadence.
 
 .. figure:: figures/architect-lifecycle-1.png
@@ -51,7 +52,12 @@ Content workflow
 ****************
 
 The *Content Workflow* (Figure 1) orchestrates the processes used to manage
-the creation of content for the distribution. This includes everything from detecting a new release in a custom software repository to generating RPM package files. The RPM files serve as intermediary artifacts that track software dependencies and provide file-level data consumed in a *Release Workflow*.  The `Watcher Pipeline`_ checks |CL| and a content provider, such as Koji, to determine if a new release is necessary.
+the creation of content for the distribution. This includes everything from
+detecting a new release in a custom software repository to generating RPM
+package files. The RPM files serve as intermediary artifacts that track software
+dependencies and provide file-level data consumed in a *Release Workflow*.  The
+`Watcher Pipeline`_ checks |CL| and a content provider, such as Koji, to
+determine if a new release is necessary.
 
 Release workflow
 ****************
@@ -67,9 +73,10 @@ new releases.
 Implementation
 **************
 
-Distro factory implements the *Release workflow*. To get started on a full implementation, visit |CL| `Distro factory documentation`_.
+Distro factory implements the *Release workflow*. To get started on a full
+implementation, visit |CL| `Distro Factory`_ documentation.
 
-.. _Distro factory documentation: https://github.com/clearlinux/clr-distro-factory/wiki#clear-linux-distro-factory
+.. _Distro Factory: https://github.com/clearlinux/clr-distro-factory/wiki#clear-linux-distro-factory
 
 .. _Release Pipeline: https://github.com/clearlinux/clr-distro-factory/wiki/Release
 

--- a/source/clear-linux/guides/maintenance/bulk-provision.rst
+++ b/source/clear-linux/guides/maintenance/bulk-provision.rst
@@ -41,7 +41,7 @@ Configuration
 =============
 
 #. Install **ICIS** by following the getting started guide on the
-   `ICIS GitHub repository`_.
+   `ICIS`_ GitHub repository.
 
 #. Create an Ister installation file and save it to the
    :file:`static/ister` directory within the web hosting directory for
@@ -116,7 +116,7 @@ Configuration
       location of the Ister configuration file.
 
 #. Write a cloud-init document to customize the instance of the installation
-   according to your requirements. The `cloud-init Read the Docs`_ provides a
+   according to your requirements. The `cloud-init`_ documentation provides a
    guide on how to write a cloud-init document. The guide covers the
    customization options provided by cloud-init after an installation.
 
@@ -158,8 +158,8 @@ Configuration
 **Congratulations!** You have successfully performed a bulk provision of |CL|.
 
 
-.. _ICIS GitHub repository:
+.. _ICIS:
    https://github.com/clearlinux/ister-cloud-init-svc
 
-.. _cloud-init Read the Docs:
+.. _cloud-init:
    https://cloudinit.readthedocs.io

--- a/source/clear-linux/guides/maintenance/cpu-performance.rst
+++ b/source/clear-linux/guides/maintenance/cpu-performance.rst
@@ -33,8 +33,8 @@ C-states aim to reduce power utilization by increasingly reducing clock
 frequency, voltages, and features in each state.
 
 Although C-states can typically be limited or disabled in a system's UEFI or
-BIOS configuration, these settings are overridden when the `intel_idle
-driver`_ is in use.
+BIOS configuration, these settings are overridden when the `intel_idle driver`_
+is in use.
 
 To view the current cpuidle driver run this command in a terminal:
 
@@ -48,7 +48,8 @@ or completely disabled with :command:`idle=poll`.
 
 .. note::
 
-   * :command:`processor.max_cstate=0` is changed to :command:`processor.max_cstate=1` by the kernel to be a valid value.
+   * :command:`processor.max_cstate=0` is changed to :command:`processor.max_cstate=1`
+     by the kernel to be a valid value.
 
    * :command:`intel_idle.max_cstate=0` disables the Intel Idle driver, not set
      it to C-state 0.
@@ -137,8 +138,8 @@ To change the CPU frequency scaling governor:
 
       echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 
-The list of all governors can be found in the `Linux kernel documentation on
-CPUFreq Governors`_.
+The list of all governors can be found in the Linux kernel documentation on
+`CPUFreq Governors`_.
 
 .. note::
 
@@ -185,7 +186,7 @@ bundle and add your user account to the power group:
 
 .. _`Intel P-state driver`: https://www.kernel.org/doc/Documentation/cpu-freq/intel-pstate.txt
 
-.. _`Linux kernel documentation on CPUFreq Governors`: https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt
+.. _`CPUFreq Governors`: https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt
 
 .. _thermald: https://01.org/linux-thermal-daemon
 

--- a/source/clear-linux/guides/maintenance/developer-workstation.rst
+++ b/source/clear-linux/guides/maintenance/developer-workstation.rst
@@ -24,7 +24,8 @@ responds to this need.
 
 Use Table 1, *Developer Profiles*, to identify the *minimum
 required bundles* to get started developing based on your role or project.
-While your role may not neatly fit in one of these categories, consider using Table 1 as a starting point.
+While your role may not neatly fit in one of these categories, consider using
+Table 1 as a starting point.
 
 .. list-table:: **Table 1. Developer Profiles**
    :widths: 20, 20, 20, 20
@@ -102,8 +103,8 @@ Other resources for developers
 -----------------------------------
 
 * `Developer Tooling Framework`_ for |CL|
-* `Bundle definition files`_
+* `Bundle Definition Files`_
 
-.. _Bundle definition files: https://github.com/clearlinux/clr-bundles
+.. _Bundle Definition Files: https://github.com/clearlinux/clr-bundles
 
 .. _Developer Tooling Framework: https://github.com/clearlinux/common

--- a/source/clear-linux/guides/maintenance/enable-user-space.rst
+++ b/source/clear-linux/guides/maintenance/enable-user-space.rst
@@ -52,7 +52,8 @@ To be able to execute all applications with root privileges, add the
 Install and update the OS software to its current version
 *********************************************************
 
-The |CL| software utility :ref:`swupd <swupd-guide>` allows you to perform system updates while reaping the benefits of upstream development.
+The |CL| software utility :ref:`swupd <swupd-guide>` allows you to perform
+system updates while reaping the benefits of upstream development.
 
 To update your newly installed OS, run:
 
@@ -69,13 +70,15 @@ to running :command:`apt-get` or :command:`yum install` for package
 management. Yet |CL| manages packages at the level of bundles, which
 are integrated stacks of packages.
 
-For example, the `sysadmin-basic` bundle installs the majority of applications useful to a system administrator. To install it, enter:
+For example, the `sysadmin-basic` bundle installs the majority of applications
+useful to a system administrator. To install it, enter:
 
 .. code-block:: bash
 
    swupd bundle-add sysadmin-basic
 
-View a full list of bundles and packages installed with the `sysadmin-basic`_ bundle. You can also view `all bundles`_ for |CL|, active or deprecated.
+View a full list of bundles and packages installed with the `sysadmin-basic`_
+bundle. You can also view all `bundles`_ for |CL|, active or deprecated.
 
 Expand your knowledge of :command:`swupd` and check out our developer resources:
 
@@ -93,7 +96,7 @@ Check out our guides and tutorials.
 .. _`sysadmin-basic`:
    https://github.com/clearlinux/clr-bundles/blob/master/bundles/sysadmin-basic
 
-.. _`all bundles`:
+.. _`bundles`:
    https://github.com/clearlinux/clr-bundles/tree/master/bundles
 
 .. _`wheel group`:

--- a/source/clear-linux/guides/maintenance/kernel-development.rst
+++ b/source/clear-linux/guides/maintenance/kernel-development.rst
@@ -6,26 +6,28 @@ Kernel development
 This document shows how to obtain and compile a Linux* kernel source
 using |CL-ATTR| development tooling.
 
-The `kernels available`_  in |CL| aim to be performant and practical. In some
-cases, it may be necessary to modify the kernel to suit your specific needs
-or test new kernel code as a developer.
+The :ref:`compatible-kernels` available in |CL| aim to be performant and
+practical. In some cases, it may be necessary to modify the kernel to suit your
+specific needs or test new kernel code as a developer.
 
 .. contents::
    :local:
    :depth: 1
    :backlinks: top
 
-Source RPM files (SRPM) are also available for all |CL| kernels, and can be
-used for development instead. Select this link to view the latest `source RPM files`_.
+Source RPM (SRPM) files are also available for all |CL| kernels, and can be
+used for development instead. Select this link to view the latest
+`SRPM`_ files.
 
 Request changes be included with the |CL| kernel
 ************************************************
 
 If the kernel modification you need is already open source and likely to be
 useful to others, consider submitting a request to include it in the
-|CL| kernels.If your change request is accepted, you do not need to maintain your own modified kernel.
+|CL| kernels.If your change request is accepted, you do not need to maintain
+your own modified kernel.
 
-Make enhancement requests to the |CL| `distribution on GitHub`_ .
+Make enhancement requests to the |CL| `Distribution Project`_ on GitHub.
 
 Set up kernel development environment
 *************************************
@@ -56,7 +58,7 @@ Clone the existing kernel package repository from |CL| as a starting point.
 #. Clone the Linux kernel package from |CL|. Using the
    :command:`make clone_<PACKAGENAME>` command in the
    :file:`clearlinux/` directory clones the package from the
-   `clearlinux-pkgs GitHub`_.
+   `clearlinux-pkgs`_ repo on GitHub.
 
    .. code-block:: bash
 
@@ -73,7 +75,7 @@ Clone the existing kernel package repository from |CL| as a starting point.
 The "linux" package is the kernel that comes with |CL| in the `kernel-native`
 bundle. Alternatively, you can use a different kernel variant as the base for
 modification. For a list of kernel package names which you can clone instead,
-see the `clearlinux-pkgs GitHub`_.
+see the `clearlinux-pkgs`_ repo on GitHub.
 
 .. note::
 
@@ -261,7 +263,7 @@ consider using a patch management tool in addition to Git such as
 
 #. Generate a patch file based on your git commits.
    <n> represents the number of local commits to create patch file.
-   See the `git-format-patch Documentation`_ for detailed information
+   See the `git-format-patch`_ documentation for detailed information
    on using :command:`git format-patch`
 
    .. code-block:: bash
@@ -355,7 +357,7 @@ are persistent and distributed with a customized kernel.
 
 #. Commit and save the changes to the :file:`cmdline` file.
 
-See the `Kernel parameters documentation`_ for a list of available
+See the `kernel parameters`_  documentation for a list of available
 parameters.
 
 Build and install the kernel
@@ -374,7 +376,9 @@ isolate building of packages in a sanitized workspace.
       make build
 
    .. note::
-      The `ccache plugin for mock`_ can be enabled to help speed up any future rebuilds of the kernel package by caching compiler outputs and reusing them.
+      The mock plugin `ccache`_ can be enabled to help speed up any future
+      rebuilds of the kernel package by caching compiler outputs and reusing
+      them.
 
 
 #. The result will be multiple :file:`.rpm` files in the :file:`rpms`
@@ -426,22 +430,18 @@ Related topics
 * :ref:`kernel-modules`
 * :ref:`mixer`
 
-.. _kernels available: https://clearlinux.org/documentation/clear-linux/reference/compatible-kernels
+.. _Distribution Project: https://github.com/clearlinux/distribution/issues/new/choose
 
-.. _distribution on GitHub: https://github.com/clearlinux/distribution/issues/new/choose
-
-.. _source RPM files: https://cdn.download.clearlinux.org/current/source/SRPMS/
+.. _SRPM: https://cdn.download.clearlinux.org/current/source/SRPMS/
 
 .. _Quilt: http://savannah.nongnu.org/projects/quilt
 
-.. _clearlinux-pkgs GitHub: https://github.com/clearlinux-pkgs
+.. _clearlinux-pkgs: https://github.com/clearlinux-pkgs
 
 .. _kernel.org: https://www.kernel.org/
 
-.. _Kernel parameters documentation: https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt
+.. _kernel parameters: https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt
 
-.. _ccache plugin for mock: https://fedoraproject.org/wiki/Mock/Plugin/CCache?rd=Subprojects/Mock/Plugin/CCache
+.. _ccache: https://fedoraproject.org/wiki/Mock/Plugin/CCache?rd=Subprojects/Mock/Plugin/CCache
 
-.. _git-format-patch Documentation: https://git-scm.com/docs/git-format-patch
-
-.. _user-setup script: https://github.com/clearlinux/common/blob/master/user-setup.sh
+.. _git-format-patch: https://git-scm.com/docs/git-format-patch

--- a/source/clear-linux/guides/maintenance/kernel-development.rst
+++ b/source/clear-linux/guides/maintenance/kernel-development.rst
@@ -3,7 +3,7 @@
 Kernel development
 ##################
 
-This document shows how to obtain and compile a Linux* kernel source
+This guide shows how to obtain and compile a Linux* kernel source
 using |CL-ATTR| development tooling.
 
 The :ref:`compatible-kernels` available in |CL| aim to be performant and
@@ -15,9 +15,8 @@ specific needs or test new kernel code as a developer.
    :depth: 1
    :backlinks: top
 
-Source RPM (SRPM) files are also available for all |CL| kernels, and can be
-used for development instead. Select this link to view the latest
-`SRPM`_ files.
+`Source RPMs (SRPMS)`_ are also available for all |CL| kernels, and can be
+used for development instead.
 
 Request changes be included with the |CL| kernel
 ************************************************
@@ -432,7 +431,7 @@ Related topics
 
 .. _Distribution Project: https://github.com/clearlinux/distribution/issues/new/choose
 
-.. _SRPM: https://cdn.download.clearlinux.org/current/source/SRPMS/
+.. _Source RPMs (SRPMS): https://cdn.download.clearlinux.org/current/source/SRPMS/
 
 .. _Quilt: http://savannah.nongnu.org/projects/quilt
 

--- a/source/clear-linux/guides/maintenance/kernel-modules-dkms.rst
+++ b/source/clear-linux/guides/maintenance/kernel-modules-dkms.rst
@@ -8,11 +8,9 @@ kernel modules that are not part of the Linux source tree, you may need to
 build out-of-tree kernel modules. Use this guide to add kernel modules with
 :abbr:`DKMS (Dynamic Kernel Module System)` or refer to :ref:`kernel-modules`.
 
-
 .. contents:: :local:
    :depth: 1
    :backlinks: top
-
 
 Description
 ***********
@@ -110,7 +108,7 @@ Build, install, and load an out-of-tree module
 Follow the steps in this section if you are an individual user or testing, and
 you need an out-of-tree kernel module that is not available through |CL|. For
 a more scalable and customizable approach, we recommend using the
-`mixer`_ tool to provide a custom kernel and updates.
+:ref:`mixer` tool to provide a custom kernel and updates.
 
 
 Prerequisites
@@ -320,8 +318,6 @@ Related topics
 * `Dell Linux Engineering Dynamic Kernel Module Support: From Theory to Practice <https://www.kernel.org/doc/ols/2004/ols2004v1-pages-187-202.pdf>`_
 
 * `Linux Journal: Exploring Dynamic Kernel Module Support <https://www.linuxjournal.com/article/6896>`_
-
-.. _mixer: https://clearlinux.org/features/mixer-tool
 
 .. _Dynamic Kernel Module System (DKMS): https://github.com/dell/dkms
 

--- a/source/clear-linux/guides/maintenance/kernel-modules-dkms.rst
+++ b/source/clear-linux/guides/maintenance/kernel-modules-dkms.rst
@@ -110,7 +110,7 @@ Build, install, and load an out-of-tree module
 Follow the steps in this section if you are an individual user or testing, and
 you need an out-of-tree kernel module that is not available through |CL|. For
 a more scalable and customizable approach, we recommend using the
-`mixer tool`_ to provide a custom kernel and updates.
+`mixer`_ tool to provide a custom kernel and updates.
 
 
 Prerequisites
@@ -218,10 +218,10 @@ Here are some additional resources that can be used for reference:
 * DKMS manual page (:command:`man dkms`) shows detailed syntax in the
   DKMS.CONF section.
 
-* `Ubuntu community wiki`_ shows an example where a single package contains
-  multiple modules.
+* Ubuntu community wiki entry for the `Kernel DKMS Package`_ shows an example
+  where a single package contains multiple modules.
 
-* `Sample dkms.conf file`_ in the GitHub\* repository for the DKMS project.
+* Sample `dkms.conf`_ file in the GitHub\* repository for the DKMS project.
 
 .. note::
 
@@ -315,20 +315,16 @@ Examples
 Related topics
 **************
 
-* `Dynamic Kernel Module System (DKMS) project on GitHub <https://github.com/dell/dkms>`_
+* `Dynamic Kernel Module System (DKMS)`_
 
 * `Dell Linux Engineering Dynamic Kernel Module Support: From Theory to Practice <https://www.kernel.org/doc/ols/2004/ols2004v1-pages-187-202.pdf>`_
 
 * `Linux Journal: Exploring Dynamic Kernel Module Support <https://www.linuxjournal.com/article/6896>`_
 
+.. _mixer: https://clearlinux.org/features/mixer-tool
 
-.. _`on GitHub`: https://github.com/clearlinux/distribution
+.. _Dynamic Kernel Module System (DKMS): https://github.com/dell/dkms
 
-.. _`mixer tool`: https://clearlinux.org/features/mixer-tool
+.. _Kernel DKMS Package: https://help.ubuntu.com/community/Kernel/DkmsDriverPackage#Configure_DKMS
 
-.. _`Dynamic Kernel Module System (DKMS)`: https://github.com/dell/dkms
-
-.. _Ubuntu community wiki: https://help.ubuntu.com/community/Kernel/DkmsDriverPackage#Configure_DKMS
-
-.. _Sample dkms.conf file: https://github.com/dell/dkms/blob/master/sample.conf
-
+.. _dkms.conf: https://github.com/dell/dkms/blob/master/sample.conf

--- a/source/clear-linux/guides/maintenance/kernel-modules.rst
+++ b/source/clear-linux/guides/maintenance/kernel-modules.rst
@@ -68,7 +68,7 @@ Build, install, and load an out-of-tree module
 Follow the steps in this section if you are an individual user or testing, and
 you need an out-of-tree kernel module that is not available through |CL|. For
 a more scalable and customizable approach, we recommend using the
-`mixer tool`_ to provide a custom kernel and updates.
+:ref:`mixer` tool to provide a custom kernel and updates.
 
 
 Prerequisites
@@ -216,5 +216,3 @@ Related topic
 *************
 
 * :ref:`kernel-modules-dkms`
-
-.. _`mixer tool`: https://clearlinux.org/features/mixer-tool

--- a/source/clear-linux/guides/maintenance/kernel-modules.rst
+++ b/source/clear-linux/guides/maintenance/kernel-modules.rst
@@ -56,7 +56,8 @@ If the kernel module you need is already open source (for example, in the Linux
 upstream) and likely to be useful to others, consider submitting a request to
 add or enable it in the |CL| kernel.
 
-Make enhancement requests to the |CL| distribution `on GitHub`_.
+Make enhancement requests to the |CL|
+`Distribution Project <https://github.com/clearlinux/distribution>`_ on GitHub.
 
 .. _kernel-modules-availability-end:
 
@@ -216,6 +217,4 @@ Related topic
 
 * :ref:`kernel-modules-dkms`
 
-
-.. _`on GitHub`: https://github.com/clearlinux/distribution
 .. _`mixer tool`: https://clearlinux.org/features/mixer-tool


### PR DESCRIPTION
- Remove unused links
- Updated links  defined as named refs to use simple text e.g. name of linked content
instead of narrative text
- Minor edits to accomodate minor changes to name of ref links

Signed-off-by: Kristal Dale <kristal.dale@intel.com>