### PR TITLE
Clean up of syntax around gui elements in preparation for translation.

### DIFF
--- a/source/clear-linux/get-started/virtual-machine-install/gce.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/gce.rst
@@ -51,10 +51,10 @@ Process
 #. Create a *Storage Bucket* for hosting the |CL| image source archive
    downloaded in the previous step:
 
-   * Click the *Navigation menu* icon on the upper left screen menu.
+   * Click the :guilabel:`Navigation menu` icon on the upper left screen menu.
 
-   * Select the *Storage* item from the side bar on the left. You will
-     be sent to the Storage Browser tool or the Cloud Storage overview page.
+   * Select the :menuselection:`Storage` item from the side bar on the left. You
+     will be sent to the Storage Browser tool or the Cloud Storage overview page.
 
    .. figure:: figures/gce/01-cloud-storage.png
       :scale: 50 %
@@ -72,12 +72,12 @@ Process
 
       Figure 3: Cloud Storage Browser tool
 
-   * Click the ``CREATE BUCKET`` button to enter the bucket creation tool.
+   * Click the :guilabel:`CREATE BUCKET` button to enter the bucket creation tool.
      The bucket name must be unique because buckets in the Cloud Storage share
      a single global namespace.
 
-     Leave the remaining options set to the defaults, and select the
-     ``Create`` button at the bottom to create a *Bucket*.
+     Leave the remaining options set to the defaults, and click the
+     :guilabel:`Create` button at the bottom to create a *Bucket*.
 
      .. figure:: figures/gce/03-create-bucket.png
         :scale: 50 %
@@ -85,7 +85,7 @@ Process
 
         Figure 4: Set bucket name
 
-#. Once the bucket is created, click the ``Upload files`` button
+#. Once the bucket is created, click the :guilabel:`Upload files` button
    on the Bucket details page to upload the |CL| GCE image archive
    to the named bucket:
 
@@ -109,9 +109,10 @@ Process
 
 #. Browse the Compute Engine Image library page:
 
-   * Click the *Navigation menu* icon on the upper left screen menu.
+   * Click the :guilabel:`Navigation menu` icon on the upper left screen menu.
 
-   * Hover your mouse over the *Compute Engine* menu and select *Images*.
+   * Select the :menuselection:`Compute Engine --> Images` from the side bar on
+     the left.
 
      .. figure:: figures/gce/20-gce-image.png
         :scale: 50 %
@@ -119,7 +120,7 @@ Process
 
         Figure 8: Image library
 
-#. On the Compute Engine Image library page, click the ``[+] CREATE IMAGE``
+#. On the Compute Engine Image library page, click the :guilabel:`[+] CREATE IMAGE`
    menu item to create a custom image:
 
    .. figure:: figures/gce/20-image-library.png
@@ -131,7 +132,7 @@ Process
 #. In the VM image creation page, change the image source type to
    *Cloud Storage file*.
 
-#. Under :guilabel:`Cloud Storage file`, select :guilabel:`Browse`.
+#. Under :guilabel:`Source`, select :guilabel:`Browse`.
 
 #. Locate the :file:`clear-<release number>-gce.tar.gz` file,
    and click :guilabel:`Select`.
@@ -142,7 +143,7 @@ Process
 
       Figure 10: Create image using imported object
 
-   Accept all default options, and click the ``Create`` button
+   Accept all default options, and click the :guilabel:`Create` button
    at the bottom to import the Clear Linux GCE image to the image library.
 
    .. figure:: figures/gce/22-image-list.png
@@ -154,10 +155,10 @@ Process
 #. After the |CL| image is imported, you can launch a VM instance running
    |CL|:
 
-   * Click the *Navigation menu* icon on the upper left screen menu.
+   * Click the :guilabel:`Navigation menu` icon on the upper left screen menu.
 
-   * Hover your mouse over the *Compute Engine* menu group and select
-     the *VM instances* item.
+   * Select :menuselection:`Compute Engine --> VM Instances` from the side bar on
+     the left.
 
    .. figure:: figures/gce/30-vm-instances.png
       :scale: 50 %
@@ -168,7 +169,7 @@ Process
 #. If no VM instance was created in this project, you will be prompted to
    create one.
 
-#. Alternatively, click the ``CREATE INSTANCE`` button on the VM
+#. Alternatively, click the :guilabel:`CREATE INSTANCE` button on the VM
    instances page to create a VM instance.
 
    .. figure:: figures/gce/30-vm-none.png
@@ -183,10 +184,10 @@ Process
 
       Figure 14: VM instances list
 
-   * In :guilabel:`Region`, choose a region based on the
+   * Under :guilabel:`Region`, choose a region based on the
      `Best practices for Compute Engine regions selection`_.
 
-   * Under *Boot disk*, click the ``Change`` button.
+   * Under :guilabel:`Boot disk`, click the :guilabel:`Change` button.
 
      .. figure:: figures/gce/30-create-vm.png
         :scale: 50 %
@@ -194,7 +195,7 @@ Process
 
         Figure 15: Use custom image
 
-   * Select the *Custom images* tab for using Clear Linux OS GCE image.
+   * Select the :menuselection:`Custom images` tab for using Clear Linux OS GCE image.
 
      .. figure:: figures/gce/31-select-boot-disk.png
         :scale: 50 %
@@ -203,7 +204,8 @@ Process
         Figure 16: Select Clear Linux boot disk to create a VM instance
 
    * Scroll down to the bottom of the VM instance creation page,
-     expand the *Management, security, disks, networking, sole tenancy* group.
+     expand the :guilabel:`Management, security, disks, networking, sole tenancy`
+     group.
 
      .. figure:: figures/gce/40-clear-vm-security.png
         :scale: 50 %
@@ -218,7 +220,7 @@ Process
 
         Refer to :ref:`security` for more details.
 
-   * Click the *Security* tab, copy and paste your SSH public key:
+   * Click the :menuselection:`Security` tab, copy and paste your SSH public key:
 
      .. figure:: figures/gce/40-ssh-key.png
         :scale: 50 %
@@ -233,7 +235,7 @@ Process
         because it is an invalid character while creating user accounts in
         |CL|.
 
-   * Click the ``Create`` button to create the |CL| VM.
+   * Click the :guilabel:`Create` button to create the |CL| VM.
 
 #. The Clear Linux VM instance is created and assigned a public IP address:
 

--- a/source/clear-linux/get-started/virtual-machine-install/virtualbox-cl-installer.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/virtualbox-cl-installer.rst
@@ -60,11 +60,11 @@ details about using different settings are available in the VirtualBox manual se
 
 #. Launch the |VBM| from your host system.
 
-#. Click the *New* button to create a new VM.
+#. Click the :guilabel:`New` button to create a new VM.
 
 #. Choose :guilabel:`Expert mode`.
 
-#. In :guilabel:`Create Virtual Machine`, enter the following settings:
+#. On the :guilabel:`Create Virtual Machine` screen, enter the following settings:
 
    - **Name**: Choose name (e.g. ClearLinuxOS-VM).
    - **Type**: Linux
@@ -82,9 +82,9 @@ details about using different settings are available in the VirtualBox manual se
 
       Figure 2: Create Virtual Machine
 
-#. Select :guilabel:`Create`.
+#. Click :guilabel:`Create`.
 
-#. In :guilabel:`Create Virtual Hard Disk`, select:
+#. On the :guilabel:`Create Virtual Hard Disk` screen, select:
 
    - **File location**
    - **File size**: **32.00 GB**. Adjust size to your needs.
@@ -97,16 +97,16 @@ details about using different settings are available in the VirtualBox manual se
 
       Figure 3: Create Virtual Hard Disk
 
-#. Click *Create*.
+#. Click :guilabel:`Create`.
 
    A new virtual machine will be created and appear in the |VBM|.
 
-#. Click *Settings* to configure the |CL| VM.
+#. Click :guilabel:`Settings` to configure the |CL| VM.
 
-#. In the left-hand menu, navigate to the :guilabel:`System` menu.
+#. In the left-hand menu, navigate to the :menuselection:`System` menu.
 
-#. In the :guilabel:`Motherboard` tab, select the `Chipset` pulldown menu,
-   and then select :guilabel:`ICH9`. See Figure 4.
+#. On the :guilabel:`Motherboard` tab, select the :guilabel:`Chipset` menu, and
+   then select :menuselection:`ICH9`. See Figure 4.
 
    .. note::
 
@@ -131,7 +131,7 @@ details about using different settings are available in the VirtualBox manual se
       machine under Settings > System > Processor for increased
       performance.
 
-#. Select :guilabel:`OK`.
+#. Click :guilabel:`OK`.
 
 Install |CL| on the |VB| VM
 ***************************
@@ -144,15 +144,15 @@ Mount the installation ISO
 The |CL| installer ISO needs to be mounted as a virtual CD-ROM on the VM
 before powering the VM on.
 
-#. From the *ClearLinux-OS* :guilabel:`Settings` at left, select
+#. From the *ClearLinux-OS* :guilabel:`Settings` menu at left, select
    :guilabel:`Storage`.
 
 #. From :guilabel:`Storage Devices`, middle column, click the blue
-   disk labeled *Empty*.
+   disk labeled :guilabel:`Empty`.
 
 #. From the :guilabel:`Attributes` menu, click the blue CD disk next to
-   the *Optical Drive* drop down menu and click *Choose Virtual Optical
-   Disk File...*
+   the :guilabel:`Optical Drive` drop down menu and click
+   :guilabel:`Choose Virtual Optical Disk File...`
 
    .. figure:: figures/vbox/virtualbox-cl-installer-05.png
       :scale: 100%
@@ -169,12 +169,12 @@ before powering the VM on.
 
       Figure 6: Mounting an ISO
 
-#. Select :guilabel:`OK` to exit and return to the main |VBM|.
+#. Click :guilabel:`OK` to exit and return to the main |VBM|.
 
 Install |CL| with live-server installer
 =======================================
 
-#. In the |VBM|, select virtual machine you created and click *Start*.
+#. In the |VBM|, select virtual machine you created and click :guilabel:`Start`.
 
    .. figure:: figures/vbox/virtualbox-cl-installer-07.png
       :scale: 100%
@@ -196,12 +196,12 @@ Install |CL| with live-server installer
    #. In :guilabel:`Configure Installation Media`, navigate top
       VBOX HARDDISK, and then select :guilabel:`Confirm`.
 
-   #. In :guilabel:`Advanced options` > :guilabel:`Manage User`, create an
+   #. In :menuselection:`Advanced options --> Manage User`, create an
       administrative user.
 
    #. Do not install the bundle `desktop-autostart`.
 
-#. When |CL| installation is complete, select :guilabel:`Exit`.
+#. When |CL| installation is complete, click :guilabel:`Exit`.
 
 #. At the prompt, enter:
 
@@ -217,16 +217,18 @@ virtual hard disk.
 
 #. Return to the |VBM|.
 
-#. Click *Settings* to configure the |CL| VM.
+#. Click :guilabel:`Settings` to configure the |CL| VM.
 
-#. From the *VM - Settings* window, navigate to the *Storage* pane from the
-   left-hand side.
+#. From the VM :guilabel:`Settings` window, navigate to the :guilabel:`Storage`
+   pane in the left menu.
 
-#. From the middle *Storage Devices* column, click the blue CD disk labeled
-   *clear-<VERSION>-live-server.iso* under the *Controller: IDE* from.
+#. From the middle :guilabel:`Storage Devices` column, click the blue CD disk
+   labeled :guilabel:`clear-<VERSION>-live-server.iso` under the
+   :guilabel:`Controller: IDE`.
 
-#. From the *Attributes* column at right, in *Optical Drive*, select the
-   blue CD icon beside and click *Remove Disk from Virtual Drive*.
+#. From the :guilabel:`Attributes` column at right, in :guilabel:`Optical Drive`,
+   select the blue CD icon beside and click
+   :guilabel:`Remove Disk from Virtual Drive`.
 
    .. figure:: figures/vbox/virtualbox-cl-installer-08.png
       :scale: 100%
@@ -234,8 +236,8 @@ virtual hard disk.
 
       Figure 8: Remove Disk from Virtual Drive
 
-#. Click *OK* to exit the *VM Settings* menu and return to the main
-   |VBM|.
+#. Click :guilabel:`OK` to exit the :guilabel:`VM Settings` menu and return to
+   the main |VBM|.
 
 Install |VB| Linux Guest Additions
 ==================================
@@ -285,8 +287,9 @@ install script in the **kernel-lts** (Long Term Support) bundle by |CL|.
       sudo swupd bundle-list | grep kernel
       sudo swupd bundle-remove <NON-LTS-KERNEL>
 
-#. In the VM Console top menu, click *Devices*, and select
-   *Insert Guest Additions CD image...* to mount the |VB| driver installation to the |CL| VM.
+#. In the VM Console top menu, click :guilabel:`Devices`, and select
+   :guilabel:`Insert Guest Additions CD image...` to mount the |VB| driver
+   installation to the |CL| VM.
 
    .. figure:: figures/vbox/virtualbox-cl-installer-09.png
       :scale: 100%
@@ -310,7 +313,7 @@ install script in the **kernel-lts** (Long Term Support) bundle by |CL|.
       Successful installation shows: "Guest Additions installation complete".
       If drivers are already installed, don't re-install them.
 
-#. Shut down the system. Select :guilabel:`Machine>ACPI Shutdown`.
+#. Shut down the system. Select :menuselection:`Machine --> ACPI Shutdown`.
 
    .. figure:: figures/vbox/virtualbox-cl-installer-10.png
       :scale: 100%


### PR DESCRIPTION
- Items clearly referring to an element in a GUI (e.g. buttons, menus,
areas in GUI/screen) updated to use :guilabel: or :menuselection: as
apprpriate.

Signed-off-by: Kristal Dale <kristal.dale@intel.com>