### PR TITLE
docs: Missing spaces after '.'s

### DIFF
--- a/source/clear-linux/get-started/virtual-machine-install/vmw-player-preconf.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/vmw-player-preconf.rst
@@ -264,7 +264,7 @@ Attach the pre-configured |CL| VMware image
 Enable UEFI boot support
 ************************
 
-|CL| needs UEFI support to boot.To enable it, add the
+|CL| needs UEFI support to boot. To enable it, add the
 following line to the end of your VM's :file:`.vmx` file:
 
 .. code-block:: console

--- a/source/clear-linux/guides/maintenance/kernel-development.rst
+++ b/source/clear-linux/guides/maintenance/kernel-development.rst
@@ -26,7 +26,7 @@ Request changes be included with the |CL| kernel
 
 If the kernel modification you need is already open source and likely to be
 useful to others, consider submitting a request to include it in the
-|CL| kernels.If your change request is accepted, you do not need to maintain
+|CL| kernels. If your change request is accepted, you do not need to maintain
 your own modified kernel.
 
 Make enhancement requests to the |CL| `Distribution Project`_ on GitHub\*.

--- a/source/clear-linux/guides/tooling/stateless.rst
+++ b/source/clear-linux/guides/tooling/stateless.rst
@@ -38,7 +38,7 @@ System areas
 ============
 File under the :file:`/usr` directory are managed by |CL| as system files.
 Files written under the :file:`/usr` directory by users can get removed
-through system updates with :ref:`swupd <swupd-about>`.This operating
+through system updates with :ref:`swupd <swupd-about>`. This operating
 assumption allows |CL| to verify and maintain integrity of system files.
 
 User areas


### PR DESCRIPTION
A `grep '\.[A-Z]'` showed up a few places where there was a space
missing after a full stop.
Initiall spotted reading the 'stateless' guide.
A similar grep for missing spaces after commas turned up nothing.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>