### PR TITLE
Corrects swupd search command; cleanup for migration

### DIFF
--- a/source/guides/clear/swupd.rst
+++ b/source/guides/clear/swupd.rst
@@ -318,7 +318,7 @@ swupd update <version number>
 swupd bundle-list [--all]
    Lists installed bundles.
 
-swupd bundle-add [-b] <search term>
+swupd bundle <search term>
    Finds a bundle that contains your search term.
 
 swupd bundle-add <bundle name>


### PR DESCRIPTION
- Removes `bundle-add`
- Removes [-b] flag; deprecated

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>