### PR TITLE
Updates to documentation header.

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/layout.html
+++ b/source/_themes/otc_tcs_sphinx_theme/layout.html
@@ -20,18 +20,20 @@
 
     <div class="header__site_info">
            <div class="header__site_info_name">
-             <a href ="https://clearlinux.org"> Clear Linux* Project</a>
            </div>
     </div>
     <nav class="header__menu">
         <ul class="header__menu_list">
-                         <li class="header__menu_list_item green  ">
+              <li class="header__menu_list_item yellow  ">
+                <a tabindex='1' href="https://clearlinux.org">Home</a>
+              </li>
+              <li class="header__menu_list_item green  ">
                 <a tabindex='1' href="https://clearlinux.org/about">About</a>
               </li>
-                         <li class="header__menu_list_item purple  ">
+              <li class="header__menu_list_item purple  ">
                 <a tabindex='1' href="https://clearlinux.org/developer">Developer</a>
               </li>
-                         <li class="header__menu_list_item blue  ">
+              <li class="header__menu_list_item blue  ">
                 <a tabindex='1' href="https://clearlinux.org/software">Software</a>
               </li>
         </ul>

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -232,6 +232,10 @@ th,td {
     /*top: 35px;*/
 }
 
+.header__menu_list_item.yellow > a::before {
+    color: #ffdf4d;
+}
+
 .header__menu_list_item.green > a::before {
     color: #009B93;
 }

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -2,7 +2,7 @@
 
 .. |CL-ATTR| replace:: Clear Linux* OS
 
-.. |CL-PRJ| replace:: Clear Linux* project
+.. |CL-PRJ| replace:: Clear Linux* Project
 
 .. |CC| replace:: Clear Containers
 


### PR DESCRIPTION
* Changed Clear Linux Project to all uppercase in substitutions.txt
* Removed link at left of header that went to clearlinux.org
* Added "home" button on right side of header that goes to clearlinux.org

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>