### PR TITLE
Fixes rendering of bullet lists in an admonition (Note).

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -272,3 +272,7 @@ th,td {
 .wy-plain-list-disc li p:last-child, .rst-content .section ul li p:last-child, .rst-content .toctree-wrapper ul li p:last-child, article ul li p:last-child {
     margin-bottom: 10px;
 }
+
+div.admonition ul {
+  margin-top: 20px;
+}


### PR DESCRIPTION
Fixed CSS problem where a bullet list inside of an admonition was being overlapped by the admonition text. Thanks @krisdale 

see: https://docs.01.org/clearlinux/latest/guides/maintenance/assign-static-ip.html

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>