### PR TITLE
Linkcheck will now only happen on deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
 script: 
   - make py
   - make htmlall
+
+before_deploy:
   - make linkcheck
 
 deploy:


### PR DESCRIPTION
Linkcheck takes a while and only needs to happen on deployment, so added to before_deploy.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>