### PR TITLE
Move guides inside networking section

### DIFF
--- a/source/guides/maintenance/custom-clear-container.rst
+++ b/source/guides/maintenance/custom-clear-container.rst
@@ -4,8 +4,8 @@ Build a custom |CL-ATTR| based Docker container image
 #######################################################
 
 This guide contains the steps to build a custom container image. The official
-base |CL-ATTR| container image is published on Docker\* Hub and is updated on a
-regular basis.
+base |CL-ATTR| container image is published on Docker\* Hub and is updated on
+a regular basis.
 
 .. contents::
    :local:
@@ -324,3 +324,4 @@ Example output:
    Removing intermediate container 7694989e97de
    Successfully built ec23189ef954
    Successfully tagged my-clearlinux-remove-pxe-server-bundle:latest
+

--- a/source/guides/network/assign-static-ip.rst
+++ b/source/guides/network/assign-static-ip.rst
@@ -14,8 +14,8 @@ scenarios such as a network with no DHCP server.
 Identify which program is managing the interface
 ************************************************
 
-New installations of |CL-ATTR| use NetworkManager as the default network interface
-manager for all network connections.
+New installations of |CL-ATTR| use NetworkManager as the default network
+interface manager for all network connections.
 
 .. note:: 
 
@@ -26,8 +26,8 @@ manager for all network connections.
      interfaces and NetworkManager was used for wireless interfaces.
 
 
-Before defining a configuration for assigning a static IP address, verify which
-program is managing the network interface.
+Before defining a configuration for assigning a static IP address, verify
+which program is managing the network interface.
 
 #. Check the output of :command:`nmcli device` to see if NetworkManager is
    managing the device.

--- a/source/guides/network/time.rst
+++ b/source/guides/network/time.rst
@@ -1,7 +1,7 @@
 .. _time:
 
-Set the time
-############
+Set system time
+###############
 
 This guide describes how to reset the time in your |CL-ATTR| system when
 the default :abbr:`NTP (Network Time Protocol)` servers cannot be reached.


### PR DESCRIPTION
This PR revises a few documents in/out of the networking guides section. It:

- Moves the static-ip document inside the network section (previously under maintenance) 
- Moves the NTP/time document inside the network section (previously under maintenance) 
- Moves the how to create CL-based docker image outside the networking section (to maintenance)
- Fix miscellaneous RST warnings
