### PR TITLE
 Stage 1 of back end support for keeping Chinese language content static in rolling release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 
 before_deploy:
   - make linkcheck
+  - tar -zcvf clearlinux-docs-zh-CN.tar.gz -C source/_build/html/zh_CN .
 
 deploy:
   - provider: pages
@@ -31,6 +32,13 @@ deploy:
     on:
       branch: development
     local_dir: source/_build/html/
+  - provider: releases
+    skip_cleanup: true
+    api_key: $GITHUB_TOKEN
+    file: clearlinux-docs-zh-CN.tar.gz
+    on:
+      tags: true
+
 
 after_deploy:
   - wget $PUBLISH_URL


### PR DESCRIPTION
Part of staged move to making language content static between tagged language releases.

* creates a release consisting of a zipped archive of the html for Chinese language

Stage 2 will build language content but only deploy from the zipped archive.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>