### PR TITLE
Deploy simplified Chinese from tagged release only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,12 @@ script:
 
 before_deploy:
   - make linkcheck
+  # only deploy the latest tagged release of Simplified Chinese docs
   - tar -zcvf clearlinux-docs-zh-CN.tar.gz -C source/_build/html/zh_CN .
+  - wget https://github.com/clearlinux/clear-linux-documentation/releases/latest/download/clearlinux-docs-zh-CN.tar.gz
+  - mkdir source/_build/html/zh_CN
+  # compress current build of Simplified Chinese in case of tagged build
+  - tar xvzf clearlinux-docs-zh-CN.tar.gz -C source/_build/zh_CN
 
 deploy:
   - provider: pages

--- a/source/Makefile
+++ b/source/Makefile
@@ -56,7 +56,7 @@ clean:
 
 htmlall: 
 	$(SPHINXBUILD) -b html $(ERROROPTS) $(ALLSPHINXOPTS) $(BUILDDIR)/html	
-	$(SPHINXBUILD) -b html $(ERROROPTS) -D language='zh_CN' $(ALLSPHINXOPTS) $(BUILDDIR)/html/zh_CN 
+	$(SPHINXBUILD) -b html $(ERROROPTS) -D language='zh_CN' $(ALLSPHINXOPTS) $(BUILDDIR)/zh_CN 
 
 htmlde:
 	$(SPHINXBUILD) -b html -D language='de' $(ALLSPHINXOPTS) $(BUILDDIR)/html/de 


### PR DESCRIPTION
* Master is now deploying only the latest tagged release of simplified Chinese into /source/_build/html/zh_CN.
* Both Chinese and English are built for error checking purposes only (parallel dirs /source/_build/html and /source/_build/zh_CN).
* Next stage will be to move building of simplified Chinese to https://github.com/clearlinux/clear-linux-documentation-zh-CN only and use latest release from that repo.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>