### PR TITLE
Deploy/Publish from publish branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ deploy:
     github_token: $GITHUB_TOKEN
     target-branch: latestHTML
     on:
-      branch: master
+      branch: publish
     local_dir: source/_build/html/
   - provider: pages
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
     target-branch: developmentHTML
     on:
-      branch: development
+      branch: master
     local_dir: source/_build/html/
   - provider: releases
     skip_cleanup: true


### PR DESCRIPTION
Docs will now deploy from publish branch. Master will now be staging to preview changes before going live.

Publishing currently requires 1 manual step:

1. merge/pull master into publish

Previewing on staging requires 1 manual step:

1. hit staging publish URL

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>