### PR TITLE
Correct example commands in autoproxy guide

### DIFF
--- a/source/guides/clear/autoproxy.rst
+++ b/source/guides/clear/autoproxy.rst
@@ -54,16 +54,16 @@ environment settings are respected and no time is wasted trying to resolve a
 proxy. All these steps happen in the background with no user interaction.
 
 Troubleshooting
-===============
+***************
 
 Autoproxy allows |CL| to operate seamlessly behind a proxy
 because :ref:`swupd <swupd-guide>` and other |CL| tools are implemented on
 top of libcurl. Tools that do not use libcurl, like git, must
-be configured independently. 
+be configured independently.
 
 If you are familiar with PAC files and WPAD, you can use
 :command:`pacdiscovery` and :command:`FindProxyForURL` to
-troubleshoot problems with autproxy.
+troubleshoot problems with autoproxy.
 
 .. note::
 
@@ -71,13 +71,17 @@ troubleshoot problems with autproxy.
 
 .. _findproxyforurl: http://findproxyforurl.com/
 
-Run :command:`pacdiscovery` with no arguments to indicate
 
-1. if there is a problem resolving the :command:`WPAD` host name resolution: 
+Run :command:`pacdiscovery` with no arguments to indicate |br|
+
+
+1. if there is a problem resolving the :command:`WPAD` host name resolution:
 
    .. code-block:: bash
 
       pacdiscovery
+
+   Sample output:
 
    .. code-block:: console
 
@@ -90,6 +94,8 @@ Run :command:`pacdiscovery` with no arguments to indicate
 
       pacdiscovery
 
+   Sample output:
+
    .. code-block:: console
 
       PAC url: http://autoproxy.your.domain.com/wpad.dat
@@ -101,42 +107,48 @@ Unmask the :command:`pacrunner` service by running:
 
    systemctl unmask pacrunner.service
 
-:command:`FindProxyForURL` with :command:`busctl` can also indicate if the
-:command:`pacrunner.service` is masked.
 
-.. code-block:: bash
 
-   busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client 
+Use :command:`FindProxyForURL` with :command:`busctl` to indicate |br|
 
-.. code-block:: console
-   
-   FindProxyForURL ss "http://www.google.com" "google.com"
-   Unit pacrunner.service is masked.
-   dig wpad, dig wpad.<domain>
+#. if the :command:`pacrunner.service` is masked:
 
-:command:`FindProxyForURL` returns the URL and port of the proxy server when
-an external URL and host are provided as arguments.
+   .. code-block:: bash
 
-.. code-block:: bash
+      busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client FindProxyForURL ss "http://www.google.com" "google.com"
 
-   busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client 
+   Sample output:
 
-.. code-block:: console
+   .. code-block:: console
 
-   FindProxyForURL ss "http://www.google.com" "google.com"
-   s "PROXY proxy.your.domain.com:<port>"
+      Unit pacrunner.service is masked.
+      dig wpad, dig wpad.<domain>
 
-If a proxy server is not avialable, or if :command:`pacrunner` is running
-without a PAC file, :command:`FindProxyForURL` will return "DIRECT". 
+#. the URL and port of the proxy server when an external URL and host are
+   provided as arguments:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client 
+      busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client FindProxyForURL ss "http://www.google.com" "google.com"
 
-.. code-block:: console 
+   Sample output:
 
-   FindProxyForURL ss "http://www.google.com" "google.com"
-   s "DIRECT"
+   .. code-block:: console
+
+      s "PROXY proxy.your.domain.com:<port>"
+
+#. if a proxy server is not available, or if :command:`pacrunner` is running
+   without a PAC file:
+
+   .. code-block:: bash
+
+      busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client FindProxyForURL ss "http://www.google.com" "google.com"
+
+   Sample output:
+
+   .. code-block:: console
+
+      s "DIRECT"
 
 Once :command:`pacdiscovery` is able to look up :command:`WPAD`, restart the
 :command:`pacrunner` service:
@@ -151,3 +163,7 @@ Once :command:`pacdiscovery` is able to look up :command:`WPAD`, restart the
    A "domain" or "search" entry in :file:`/etc/resolv.conf` is required
    for short name lookups to resolve. The :file:`resolv.conf` man page has
    additional details.
+
+.. |br| raw:: html
+
+   <br><br>

--- a/source/guides/clear/autoproxy.rst
+++ b/source/guides/clear/autoproxy.rst
@@ -78,7 +78,7 @@ Run :command:`pacdiscovery` with no arguments to indicate |br|
 
    .. code-block:: bash
 
-      pacdiscovery
+      sudo pacdiscovery
 
    Sample output:
 
@@ -91,7 +91,7 @@ Run :command:`pacdiscovery` with no arguments to indicate |br|
 
    .. code-block:: bash
 
-      pacdiscovery
+      sudo pacdiscovery
 
    Sample output:
 
@@ -104,7 +104,7 @@ Unmask the :command:`pacrunner` service by running:
 
 .. code-block:: bash
 
-   systemctl unmask pacrunner.service
+   sudo systemctl unmask pacrunner.service
 
 
 
@@ -154,8 +154,8 @@ Once :command:`pacdiscovery` is able to look up :command:`WPAD`, restart the
 
 .. code-block:: bash
 
-   systemctl stop pacrunner
-   systemctl restart pacdiscovery
+   sudo systemctl stop pacrunner
+   sudo systemctl restart pacdiscovery
 
 .. note::
 

--- a/source/guides/clear/autoproxy.rst
+++ b/source/guides/clear/autoproxy.rst
@@ -74,8 +74,7 @@ troubleshoot problems with autoproxy.
 
 Run :command:`pacdiscovery` with no arguments to indicate |br|
 
-
-1. if there is a problem resolving the :command:`WPAD` host name resolution:
+#. if there is a problem resolving the :command:`WPAD` host name resolution:
 
    .. code-block:: bash
 
@@ -88,7 +87,7 @@ Run :command:`pacdiscovery` with no arguments to indicate |br|
       failed getaddrinfo: No address associated with hostname
       Unable to find wpad host
 
-2. or if the :command:`pacrunner` service is disabled (masked).
+#. or if the :command:`pacrunner` service is disabled (masked).
 
    .. code-block:: bash
 
@@ -111,6 +110,19 @@ Unmask the :command:`pacrunner` service by running:
 
 Use :command:`FindProxyForURL` with :command:`busctl` to indicate |br|
 
+#. the URL and port of the proxy server when an external URL and host are
+   provided as arguments:
+
+   .. code-block:: bash
+
+      busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client FindProxyForURL ss "http://www.google.com" "google.com"
+
+   Sample output showing proxy was found:
+
+   .. code-block:: console
+
+      s "PROXY proxy.your.domain.com:<port>"
+
 #. if the :command:`pacrunner.service` is masked:
 
    .. code-block:: bash
@@ -124,19 +136,6 @@ Use :command:`FindProxyForURL` with :command:`busctl` to indicate |br|
       Unit pacrunner.service is masked.
       dig wpad, dig wpad.<domain>
 
-#. the URL and port of the proxy server when an external URL and host are
-   provided as arguments:
-
-   .. code-block:: bash
-
-      busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client FindProxyForURL ss "http://www.google.com" "google.com"
-
-   Sample output:
-
-   .. code-block:: console
-
-      s "PROXY proxy.your.domain.com:<port>"
-
 #. if a proxy server is not available, or if :command:`pacrunner` is running
    without a PAC file:
 
@@ -144,7 +143,7 @@ Use :command:`FindProxyForURL` with :command:`busctl` to indicate |br|
 
       busctl call org.pacrunner /org/pacrunner/client org.pacrunner.Client FindProxyForURL ss "http://www.google.com" "google.com"
 
-   Sample output:
+   Sample output, indicating connection made directly, without proxy:
 
    .. code-block:: console
 


### PR DESCRIPTION
- Fix example commands that were split into two snippets (should be one)
- Spelling corrections and minor edits for readability

Fixes #795

Signed-off-by: Kristal Dale <kristal.dale@intel.com>