### PR TITLE
Adds labels for code blocks used in Clear Linux docs

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -344,3 +344,67 @@ div#trademarks {
 }
 
 /*End support for code blocks with $ signs that aren't copied with content*/
+
+/*Begin support for labeled code-blocks - need to add an entry for every type of code-block that needs to be labeled*/
+
+div.highlight-powershell .highlight:before{
+  background: #909090;
+  color: white;
+  content: " PowerShell ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-python .highlight:before{
+  background: #909090;
+  color: white;
+  content: " Python ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-console .highlight:before{
+  background: #909090;
+  color: white;
+  content: " Console ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-rst, div.highlight-rest .highlight:before{
+  background: #909090;
+  color: white;
+  content: " reStructuredText ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-yaml .highlight:before{
+  background: #909090;
+  color: white;
+  content: " yaml ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-bash .highlight:before{
+  background: #909090;
+  color: white;
+  content: " bash ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.linenodiv:before { /*add extra new line to make sure code and line numbers align*/
+   content: '\00000a';
+   white-space: pre;
+}
+
+/*End support for labeled code-blocks*/
+

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -401,6 +401,69 @@ div.highlight-bash .highlight:before{
   white-space: pre;
 }
 
+div.highlight-diff .highlight:before{
+  background: #909090;
+  color: white;
+  content: " Diff ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-c .highlight:before{
+  background: #909090;
+  color: white;
+  content: " c ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-json .highlight:before{
+  background: #909090;
+  color: white;
+  content: " json ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-spec .highlight:before{
+  background: #909090;
+  color: white;
+  content: " spec ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-perl .highlight:before{
+  background: #909090;
+  color: white;
+  content: " Perl ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-php .highlight:before{
+  background: #909090;
+  color: white;
+  content: " php ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-xml .highlight:before{
+  background: #909090;
+  color: white;
+  content: " xml ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
 div.linenodiv:before { /*add extra new line to make sure code and line numbers align*/
    content: '\00000a';
    white-space: pre;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13109946/66498541-1a022e80-ea73-11e9-8ce1-83c80352127c.png)

Code blocks that do not have labels remain the same as before. Currently the  "none" code block is the only type in the docs that does not have a handler. 

Known issues:

1. Code blocks that do not have a label and have line numbers turned on will be mis-aligned. Currently no instances of this.
2. When line numbers are turned on the code block label appears to the right of the line numbers:

![image](https://user-images.githubusercontent.com/13109946/66498455-ef17da80-ea72-11e9-9da9-a93761cd388f.png)

Current list of code blocks with labels:

* yaml
* bash
* console
* reStructuredText
* Python
* PowerShell
* Diff
* C
* json
* spec
* Perl
* PHP
* xml