### PR TITLE
Remove -version flag from os-install command

### DIFF
--- a/source/guides/maintenance/container-image-new.rst
+++ b/source/guides/maintenance/container-image-new.rst
@@ -90,15 +90,14 @@ Build the base container image
 
    .. code-block:: bash
 
-      swupd os-install --url https://cdn.download.clearlinux.org/update --statedir "$PWD"/swupd-state --no-boot-update  -B os-core-update,editors,network-basic base
+      swupd os-install --url https://cdn.download.clearlinux.org/update --statedir "$PWD"/swupd-state --no-boot-update -B os-core-update,editors,network-basic base
 
 
    The swupd example uses the following flags:
 
    * :command:`os-install` tells swupd to download and install.
    * :command:`--url` specifies the URL of the bundles repository.
-   * :command:`--statedir` specifies the state directory where downloaded bundles
-     and any state information are stored.
+   * :command:`--statedir` specifies the state directory where downloaded bundles and any state information are stored.
    * :command:`--no-boot-update` tells swupd to skip updating boot files because
      boot files are not required for a container.
 

--- a/source/guides/maintenance/container-image-new.rst
+++ b/source/guides/maintenance/container-image-new.rst
@@ -90,13 +90,12 @@ Build the base container image
 
    .. code-block:: bash
 
-      swupd os-install --url https://cdn.download.clearlinux.org/update --statedir "$PWD"/swupd-state --no-boot-update --version 29790 -B os-core-update,editors,network-basic base
+      swupd os-install --url https://cdn.download.clearlinux.org/update --statedir "$PWD"/swupd-state --no-boot-update  -B os-core-update,editors,network-basic base
 
 
    The swupd example uses the following flags:
 
    * :command:`os-install` tells swupd to download and install.
-   * :command:`-V / --version` specifies the version of the |CL| bundles.
    * :command:`--url` specifies the URL of the bundles repository.
    * :command:`--statedir` specifies the state directory where downloaded bundles
      and any state information are stored.
@@ -324,4 +323,3 @@ Example output:
    Removing intermediate container 7694989e97de
    Successfully built ec23189ef954
    Successfully tagged my-clearlinux-remove-pxe-server-bundle:latest
-


### PR DESCRIPTION
The --version flag points to an old version of Clear Linux, and is not necessary. 