### PR TITLE
Update compatible version to CL-31130; replace bundles to install in dpdk

### DIFF
--- a/source/guides/network/dpdk.rst
+++ b/source/guides/network/dpdk.rst
@@ -32,13 +32,13 @@ This example uses the following DPDK components:
 Prerequisites
 *************
 
-*  Two platforms using |CL-ATTR| release `13330`_ or higher.
+*  Two platforms using |CL-ATTR| release `31130`_ or higher.
 *  Both images must include the :command:`kernel-native` bundle.
 *  Install the :command:`network-basic-dev` bundle with the command:
 
    .. code-block:: bash
 
-      sudo swupd bundle-add network-basic-dev
+      sudo swupd bundle-add dpdk devpkgdpdk
 
 *  Each platform must have at least one :abbr:`NIC (Network Interface Card)`.
    Check the `DPDK project`_ for the list of supported `dpdk.org NICs`_.
@@ -65,14 +65,14 @@ Install dpdk and build l3fwd example (Platform B)
 
    .. code-block:: bash
 
-      sudo export RTE_TARGET=x86_64-native-linuxapp-gcc
+      sudo export RTE_TARGET=x86_64-native-linux-gcc
 
 #. Build the `l3fwd` application and add the configuration header to
    the :makevar:`CFLAGS` variable.
 
    .. code-block:: bash
 
-      sudo make CFLAGS+="-include /usr/include/rte_config.h"
+      sudo make
 
 
 Build pktgen (Platform A)
@@ -92,7 +92,7 @@ Build pktgen (Platform A)
 
    .. code-block:: bash
 
-      sudo export RTE_TARGET=x86_64-native-linuxapp-gcc
+      sudo export RTE_TARGET=x86_64-native-linux-gcc
 
 #. Build the `pktgen` project and set the :makevar:`CONFIG_RTE_BUILD_SHARED_LIB` variable
    to "n".
@@ -224,7 +224,7 @@ Run pktgen application (Platform A)
 
    .. code-block:: bash
 
-      sudo ./app/app/x86_64-native-linuxapp-gcc/pktgen -c 0xf -n 4 -- -p 0xf -P -m "1.0, 2.1"
+      sudo ./app/app/x86_64-native-linux-gcc/pktgen -c 0xf -n 4 -- -p 0xf -P -m "1.0, 2.1"
 
 #. Enable active colorful output (optional).
 

--- a/source/guides/network/dpdk.rst
+++ b/source/guides/network/dpdk.rst
@@ -34,7 +34,7 @@ Prerequisites
 
 *  Two platforms using |CL-ATTR| release `31130`_ or higher.
 *  Both images must include the :command:`kernel-native` bundle.
-*  Install the :command:`network-basic-dev` bundle with the command:
+*  Install the following two packages:
 
    .. code-block:: bash
 
@@ -343,7 +343,7 @@ machines control the NICs on the host.
 #. Run the :file:`start_qemu.sh` script.
 
 
-.. _13330: https://cdn.download.clearlinux.org/releases/13330/
+.. _31130: https://cdn.download.clearlinux.org/releases/31130/clear/
 .. _DPDK project: http://dpdk.org
 .. _dpdk.org NICs: http://dpdk.org/doc/nics
 .. _pktgen tar package: http://dpdk.org/browse/apps/pktgen-dpdk/refs

--- a/source/guides/network/dpdk.rst
+++ b/source/guides/network/dpdk.rst
@@ -34,11 +34,11 @@ Prerequisites
 
 *  Two platforms using |CL-ATTR| release `31130`_ or higher.
 *  Both images must include the :command:`kernel-native` bundle.
-*  Install the following two packages:
+*  Install the following packages:
 
    .. code-block:: bash
 
-      sudo swupd bundle-add dpdk devpkgdpdk
+      sudo swupd bundle-add network-basic-dev dpdk devpkg-dpdk
 
 *  Each platform must have at least one :abbr:`NIC (Network Interface Card)`.
    Check the `DPDK project`_ for the list of supported `dpdk.org NICs`_.


### PR DESCRIPTION
- Replace network-basic-dev w/ dpdk, devepkg-dpdk
- Revise instances of linuxapp to linux and other commands
- Align with https://github.com/clearlinux/distribution/issues/1266
- Closes GH-822

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>