### PR TITLE
Remove AES requirement from Sys Req doc

### DIFF
--- a/source/reference/system-requirements.rst
+++ b/source/reference/system-requirements.rst
@@ -4,7 +4,8 @@ Recommended minimum system requirements
 #######################################
 
 |CL-ATTR| can run on most modern hardware and is capable of running with
-modest hardware resources. Out of the box, |CL| can run on a single CPU core, 1 GB RAM, and 2 GB of disk space.
+modest hardware resources. Out of the box, |CL| can run on a single CPU core, 1
+GB RAM, and 2 GB of disk space.
 
 For use cases requiring minimal resources, |CL| :ref:`about <about>` can
 be used to create a highly customized installation that can even run on a
@@ -44,7 +45,6 @@ these features:
   - Supplemental Streaming SIMD Extension 3 (Intel® SSSE3)
   - Intel® Streaming SIMD Extensions 4.1 (Intel® SSE 4.1)
   - Intel® Streaming SIMD Extensions 4.2 (Intel® SSE 4.2)
-  - Intel® Advanced Encryption Standard New Instructions (Intel® AES-NI)
   - Carry-less Multiplication (PCLMUL)
 
 The following processor families have been verified to run |CL|:


### PR DESCRIPTION
Remove AES requirement from the recommended minimum system requirements.
AES has been removed as a hard requirement for installation.

Closes #840

Signed-off-by: Kristal Dale <kristal.dale@intel.com>