### PR TITLE
Add tutorial for PHP install & config

### DIFF
--- a/source/tutorials/php.rst
+++ b/source/tutorials/php.rst
@@ -1,0 +1,128 @@
+.. _php:
+
+Installing and Configuring PHP
+******************************
+
+This tutorial describes how to configure and use PHP and PHP extensions on |CL-ATTR|. Although we specifically address PHP this tutorial can serve as a general guide for working with applications in the |CL| :ref:`stateless` environment.
+
+We will focus on enabling PHP and PHP extensions in |CL|.  For a complete :abbr:`LAMP (Linux, Apache, MySQL, PHP)` setup in |CL| refer to the :ref:`web-server-install` section of the :ref:`wordpress` tutorial. For this tutorial you do not need to install MariaDB or WordPress.
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+Prerequisites
+*************
+
+* :ref:`Install <bare-metal-install-desktop>` |CL| on your host system
+* Follow :ref:`web-server-install` to install Apache\* and PHP
+
+
+Configuring PHP
+***************
+
+.. important::
+
+   This tutorial does not cover configuring the php-fpm service. There is a difference between php and php-fpm here. php-fpm sets configuration for the process management and pools of worker bees, and can optionally set some of the values defined in the :file:`php.ini` file. This tutorial is only looking at the PHP configuration directives, not those of php-fpm.
+
+
+By default PHP looks for configuration settings in the :file:`php.ini` file, which resides in the `usr/share/defaults/php/` path. Because |CL| is designed to be a :ref:`stateless` operating system, you must create an optional configuration file to override the default values. Every time :command:`swupd` updates the system it will overwrite changes to the `/usr/share/defaults` file structure.
+
+
+Beginning with |CL| version 31020, PHP has been modified to check for :file:`.ini` files in the /etc/php.d file structure.
+
+You can verify the version of |CL| with :command:`swupd info`
+
+.. code-block:: bash
+
+    sudo swupd info
+
+You will see output similar to:
+
+.. code-block:: console
+
+   Distribution:      Clear Linux OS
+   Installed version: 31310
+   Version URL:       https://cdn.download.clearlinux.org/update
+   Content URL:       https://cdn.download.clearlinux.org/update
+
+
+You can create a :file:`php.ini` as follows:
+
+.. code-block:: bash
+
+   sudo mkdir -p /etc/php.d
+   sudo touch /etc/php.d/php.ini
+
+This file can be edited with any of your specific configuration requirements, and will not be overwritten when swupd performs an update. The `PHP configuration file`_ documentation has complete detail about what you can set in this file.
+
+You can verify the location of the PHP configuration files with the :command:`php --ini` command:
+
+.. code-block:: bash
+
+   php --ini
+
+You should see output like this
+
+.. code-block:: console
+
+   Configuration File (php.ini) Path: /usr/share/defaults/php/
+   Loaded Configuration File:         /usr/share/defaults/php/php.ini
+   Scan for additional .ini files in: /etc/php.d
+   Additional .ini files parsed:      (none)
+
+
+This output indicates that PHP will read the php.ini file from `/usr/share/defaults/php` and will then load any further configuration from :file:`.ini` files in `/etc/php.d/`. We will create a :file:`php.ini` file in `/etc/php.d` for our use, and allow the defaults to be read from `/usr/share/defaults/php/`.
+
+
+Install PHP extensions
+**********************
+
+PHP extensions are compiled libraries designed to enable specific functions in your PHP code. |CL| provides PHP extensions in the :file:`php-extras` bundle.  Install the bundle with swupd:
+
+.. code-block:: bash
+
+   sudo swupd bundle-add php-extras
+
+You can see the list of extensions included in the `php-extras`_ bundle on the |CL| `Store`_.
+
+
+Enable PHP extensions
+*********************
+
+To enable an installed extension we need to add it to the :file:`php.ini` for the composer to use it.
+
+#. Create the :file:`php.ini` file, with the directive to load the php-imagick extension
+
+   .. code-block:: bash
+
+      sudo echo "extension=imagick.so" >> /etc/php.d/php.ini
+
+
+No further detail is required to load the extension, but you must restart the httpd service for PHP to pick up the modification to the `/etc/php.d/php.ini` file.
+
+   .. code-block:: bash
+
+      sudo systemctl restart httpd
+
+You can verify that the imagick extension has been loaded by searching through the runtime list of loaded PHP Modules.
+
+   .. code-block:: bash
+
+      php -m | grep imagick
+
+
+.. note::
+
+   Enabling an extension only requires that it be installed, added to the php.ini file and that the httpd service is restarted. However extensions may have configuration options.  These will be documented by the extension maintainer.  The options you need can be added to the :file:`/etc/php.d/php.ini` file as described by the documentation for the extension.  Be sure to restart httpd after making changes to the file.
+
+
+
+
+
+.. _php-extras: https://clearlinux.org/software/bundle/php-extras
+
+.. _Store: https://clearlinux.org/software/
+
+.. _PHP configuration file: https://www.php.net/manual/en/configuration.file.php

--- a/source/tutorials/php.rst
+++ b/source/tutorials/php.rst
@@ -39,7 +39,7 @@ Configure PHP
    This section does not cover configuring the PHP-FPM service. There is a difference between the two configurations. This section is only looking at the PHP configuration directives, not those of PHP-FPM.
 
 
-By default PHP looks for configuration settings in the :file:`php.ini` file, which resides in the `usr/share/defaults/php/` path. Because |CL| is designed to be a :ref:`stateless` operating system, you must create an optional configuration file to override the default values. Every time :command:`swupd` updates the system it will overwrite changes to the :file:`/usr/share/defaults` file structure. To save you configuration options through updates, you must create a PHP configuration file in a location that will not be overwritten. The recommended location is within the :file:`/etc` file structure.  For PHP we will create a :file:`/etc/php.d` directory for all PHP config files.
+By default PHP looks for configuration settings in the :file:`php.ini` file, which resides in the :file:`usr/share/defaults/php/` path. Because |CL| is designed to be a :ref:`stateless` operating system, you must create an optional configuration file to override the default values. Every time :command:`swupd` updates the system it will overwrite changes to the :file:`/usr/share/defaults` file structure. To save your configuration options through updates, you must create a PHP configuration file in a location that will not be overwritten. The recommended location is within the :file:`/etc` file structure.  For PHP we will create a :file:`/etc/php.d` directory for all PHP config files.
 
 Create a :file:`php.ini`.
 
@@ -48,9 +48,9 @@ Create a :file:`php.ini`.
    sudo mkdir -p /etc/php.d
    sudo touch /etc/php.d/my-php.ini
 
-This file can be edited with any of your specific configuration requirements, and will not be overwritten when swupd performs an update. The `PHP configuration file`_ documentation has complete detail about what you can set in this file.
+This file can be edited with any of your specific configuration requirements, and will not be overwritten when :command:`swupd` performs an update. The `PHP configuration file`_ documentation has complete detail about what you can set in this file.
 
-You can verify the location of the PHP configuration files with the :command:`php --ini` command:
+Verify the location of the PHP configuration files with the :command:`php --ini` command:
 
 .. code-block:: bash
 
@@ -66,7 +66,7 @@ You should see output like this
    Additional .ini files parsed:
 
 
-This output indicates that PHP will read the php.ini file from `/usr/share/defaults/php` and will then load any further configuration from :file:`.ini` files in `/etc/php.d/`. We use the :file:`my-php.ini` file in `/etc/php.d` for our specific needs, and allow the defaults to be read from `/usr/share/defaults/php/`. Note that the :file:`my-php.ini` file is not parsed yet -- this is because the file has no content at this point, and is disregarded.
+This output indicates that PHP will read the php.ini file from :file:`/usr/share/defaults/php` and will then load any further configuration from :file:`.ini` files in :file:`/etc/php.d/`. We use the :file:`my-php.ini` file in :file:`/etc/php.d` for our specific needs, and allow the defaults to be read from :file:`/usr/share/defaults/php/`. Note that the :file:`my-php.ini` file has not been parsed yet -- this is because the file has no content at this point, and is disregarded.
 
 
 Install PHP extensions
@@ -78,7 +78,7 @@ PHP extensions are compiled libraries designed to enable specific functions in y
 
    sudo swupd bundle-add php-extras
 
-You can see the list of extensions included in the `php-extras`_ bundle on the |CL| `Store`_.
+Find the list of extensions included in the `php-extras`_ bundle on the |CL| `Store`_.
 
 
 Enable PHP extensions
@@ -93,13 +93,13 @@ Create the :file:`my-php.ini` file, with the directive to load the php-imagick e
    sudo echo "extension=imagick.so" >> /etc/php.d/my-php.ini
 
 
-No further detail is required to load the extension, but you must restart the php-fpm service for PHP to pick up the modification to the `/etc/php.d/my-php.ini` file.
+No further detail is required to load the extension, but you must restart the php-fpm service for PHP to pick up the modification to the :file:`/etc/php.d/my-php.ini` file.
 
 .. code-block:: bash
 
    sudo systemctl restart php-fpm
 
-You can verify that the imagick extension has been loaded by searching through the runtime list of loaded PHP Modules.
+Verify that the imagick extension has been loaded by searching through the runtime list of loaded PHP Modules.
 
 .. code-block:: bash
 
@@ -108,12 +108,12 @@ You can verify that the imagick extension has been loaded by searching through t
 
 .. note::
 
-   To enable an extension, you must install it, add it to the :file:`php.ini` file, and restart the :file:`php-fpm` service. However, some extensions may have configuration options, which will be documented by the extension maintainer. Add the options you need to the :file:`/etc/php.d/my-php.ini` file as described in the extension's documentation. Be sure to restart :file:`php-fpm` after changing the file.
+   To enable an extension, you must install it, add it to the :file:`my-php.ini` file, and restart the :file:`php-fpm` service. However, some extensions may have configuration options, which will be documented by the extension maintainer. Add the options you need to the :file:`/etc/php.d/my-php.ini` file as described in the extension's documentation. Be sure to restart :file:`php-fpm` after changing the file.
 
 Configure PHP-FPM
 *****************
 
-The PHP-FPM configuration file is separate from the :file:`php.ini` file used by PHP. |CL| installs the default :file:`php-fpm.conf` file in /usr/share/defaults/php and this file will be overwritten with its default values during each software update. However, PHP-FPM requires that the configuration file exist in that location, and by design will not read configuration options from a different path.
+The PHP-FPM configuration file is separate from the :file:`php.ini` file used by PHP. |CL| installs the default :file:`php-fpm.conf` file in :file:`/usr/share/defaults/php` and this file will be overwritten with its default values during each software update. However, PHP-FPM requires that the configuration file exist in that location, and by design will not read configuration options from a different path.
 
 One solution to changing PHP-FPM configuration options in |CL| is to manually override the php-fpm.service unit in systemd to pass an explicit location to a custom :file:`php-fpm.conf` file.
 

--- a/source/tutorials/wordpress/web-server-install.rst
+++ b/source/tutorials/wordpress/web-server-install.rst
@@ -25,8 +25,8 @@ Apache is an open source HTTP web server application that can run on several
 operating systems, including |CL|. Go to the `Apache HTTP Server Project`_
 for more information.
 
-Install the web-server-basic bundle
-===================================
+Install the httpd bundle
+========================
 
 The **httpd** bundle contains the packages needed to install the
 Apache software bundle on |CL|.

--- a/source/tutorials/wordpress/web-server-install.rst
+++ b/source/tutorials/wordpress/web-server-install.rst
@@ -28,7 +28,7 @@ for more information.
 Install the web-server-basic bundle
 ===================================
 
-The **web-server-basic** bundle contains the packages needed to install the
+The **httpd** bundle contains the packages needed to install the
 Apache software bundle on |CL|.
 
 .. note::
@@ -44,7 +44,7 @@ Apache software bundle on |CL|.
 
    .. code-block:: bash
 
-      sudo swupd bundle-add web-server-basic
+      sudo swupd bundle-add httpd
 
 
 #. To start the Apache service, enter the following commands:


### PR DESCRIPTION
@puneetse please take a look, does this need more info on php-fpm? Do I need to add anything for people who have |CL| older than 31020 for forcing PHP to read /etc/php.d paths? 
@MCamp859 does it read ok?  It feels choppy to me, I'd be happy for any suggestions. 