### PR TITLE
Update nvidia-cuda.rst

### DIFF
--- a/source/tutorials/nvidia-cuda.rst
+++ b/source/tutorials/nvidia-cuda.rst
@@ -184,7 +184,7 @@ installed.
 
    .. code-block:: bash
 
-      /usr/local/cuda/bin/nvcc --version
+      /opt/cuda/bin/nvcc --version
       
       
 The CUDA Toolkit is now installed and can be used to compile and run CUDA


### PR DESCRIPTION
The installation path is set to /opt so the path to test nvcc needs to be updated.