### PR TITLE
Fix in tcs_theme.css for rest code blocks.

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -374,7 +374,16 @@ div.highlight-console .highlight:before{
   white-space: pre;
 }
 
-div.highlight-rst, div.highlight-rest .highlight:before{
+div.highlight-rst .highlight:before{
+  background: #909090;
+  color: white;
+  content: " reStructuredText ";
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+  font-size: 14px;
+  white-space: pre;
+}
+
+div.highlight-rest .highlight:before{
   background: #909090;
   color: white;
   content: " reStructuredText ";


### PR DESCRIPTION
Fixes a problem caused by there being two ways of indicating reStructuredText code blocks:

* rst
* rest

Now both are handled gracefully.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>