### PR TITLE
Fixes a problem where nested collapsible sections do not expand correctly.

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -175,7 +175,7 @@ th,td {
 
 .content-collapse {
   overflow: hidden;
-  transition: max-height 0.2s ease-out;
+  /*transition: max-height 0.2s ease-out;*//*removed as it was breaking nested collapsible sections*/
 }
 
 /*Fix for permalinks to collapsible sections*/

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.js
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.js
@@ -11,6 +11,21 @@ for (i = 0; i< bashDollarDivs.length; i++) {
     }
 }
 
+//needed for nested collapsible sections - otherwise the top container 
+//won't resize after expanding a child.
+function resetActiveCollapsedSections() {
+
+  var sections = document.getElementsByClassName("content-collapse section");
+
+  //for (i = 0; i < sections.length; i++) {
+  for (i = sections.length -1; i >= 0; i-- ){
+
+    if (sections[i].style.maxHeight != "0px"){
+       sections[i].style.maxHeight = sections[i].scrollHeight + "px";
+    }
+  }
+}
+
 for (i = 0; i < contents.length; i++) {
 
   //Make sure the "content-collapse section" class is occurring in <div>
@@ -50,6 +65,7 @@ for (i = 0; i < contents.length; i++) {
         } else {
           content.style.maxHeight = content.scrollHeight + "px";
         } 
+        resetActiveCollapsedSections(); //reset the size of parent containers
       });
 
       //Add the button to the page and remove the header


### PR DESCRIPTION
Discovered this in another project. Verified that this solution works to three deep collapsible sections.

Documents impacted:

* Mixer (5 sections in reference section):  https://docs.01.org/clearlinux/latest/guides/clear/mixer.html#references

Changes:

* tcs_theme.css
  * removed transition from CSS as this was blocking the fix from working properly. Removing it also
has no perceivable impact to the expanding and contracting of sections.
* tcs_theme.js (see note below explaining why the whole doc appears to have changed)
  * added function that refreshes the `max-height` attribute of all the collapsible sections from the bottom to the top of the doc (lines 16-27). 
  * added call of function in the button listener that fires when sections are expanded (line 68).

Note: Somehow Windows line endings snuck into tcs_theme.js. Used dos2unix to fix.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>