### PR TITLE
Fixes links that appear to be broken.

### DIFF
--- a/source/get-started/ipxe-install.rst
+++ b/source/get-started/ipxe-install.rst
@@ -553,10 +553,10 @@ Verify setup
 
 Verify you can access these URLs before deploying:
 
-* http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${IPXE_APP_NAME}/ipxe_boot_script.ipxe
-* http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${CLR_INSTALLER_CONF_DIR}/clr-desktop.yaml
-* http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${CLR_INSTALLER_CONF_DIR}/clr-server.yaml
-* http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${CLR_INSTALLER_CONF_DIR}/add-issue.sh
+* \http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${IPXE_APP_NAME}/ipxe_boot_script.ipxe
+* \http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${CLR_INSTALLER_CONF_DIR}/clr-desktop.yaml
+* \http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${CLR_INSTALLER_CONF_DIR}/clr-server.yaml
+* \http://{$IPXE_LAN_IP}:{$IPXE_PORT}/${CLR_INSTALLER_CONF_DIR}/add-issue.sh
 
 Deploy
 ******


### PR DESCRIPTION
Fixes reference URLS that were being automatically turned into active links that don't go anywhere.

Simple fix - escape the URL by adding "\".

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>