### PR TITLE
dpdk.rst: Fixes Figure caption indent (see pr 896)

### DIFF
--- a/source/guides/network/dpdk.rst
+++ b/source/guides/network/dpdk.rst
@@ -171,7 +171,7 @@ cables as shown in figure 2.
 
 .. figure:: ./figures/pyshical_net.png
 
-    Figure 2: Physical network environment
+   Figure 2: Physical network environment
 
 
 Run l3fwd application (Platform B)


### PR DESCRIPTION
- This PR doesn't close pr 896 because there are multiple files to be fixed. Last PR will close pr 896.

Signed-off-by: Doug Martin <doug.martin@intel.com>