### PR TITLE
Windows command sha512 -> SHA512

### DIFF
--- a/source/guides/maintenance/download-verify-decompress.rst
+++ b/source/guides/maintenance/download-verify-decompress.rst
@@ -142,7 +142,7 @@ checksum file designated with the suffix `-SHA512SUMS`.
 
     .. code-block:: bash
 
-        CertUtil -hashfile ./clear-[version number]-[image type].[compression type] sha512
+        CertUtil -hashfile ./clear-[version number]-[image type].[compression type] SHA512
 
 #.  Manually compare the output with the original checksum value shown in
     the downloaded checksum file and make sure they match.


### PR DESCRIPTION
The command fails (on my computer) unless the hash algorithm is passed as uppercase.
As per https://answers.microsoft.com/en-us/windows/forum/all/certutil-hashfile-sha1-failed/1a9f31fa-bdf5-4c63-8e72-91608606ba14
Also, I didn't try to modify line 176 and I don't think I did, but for some reason, it shows up on the diff.