### PR TITLE
Update note on wireless in live-server getting started

### DIFF
--- a/source/get-started/bare-metal-install-server.rst
+++ b/source/get-started/bare-metal-install-server.rst
@@ -38,12 +38,8 @@ Install |CL| on your target system
 **********************************
 
 Ensure that your system is configured to boot UEFI. The installation method
-described below requires a wired Internet connection with DHCP.
+described below requires a wired or wireless Internet connection with DHCP.
 
-.. note::
-
-   Alternatively, you can install |CL| over a wireless connection by first
-   using `nmtui`. Follow the `nmtui` instructions shown in Figure 2.
 
 Follow these steps to install |CL| on the target system:
 
@@ -89,6 +85,12 @@ Launch the |CL| Installer
       :alt: root login
 
       Figure 2: root login
+
+#. .. note::
+
+      If a wireless connection is needed, connect to the network using
+      :command:`nmtui` before lauching the installer. See the documentation on
+      :ref:`configuring Wifi with nmtui <wifi-nm-tui>` for more details.
 
 #. At the :guilabel:`root` prompt, enter :command:`clr-installer` and
    press :kbd:`Enter`.

--- a/source/get-started/bare-metal-install-server.rst
+++ b/source/get-started/bare-metal-install-server.rst
@@ -490,7 +490,8 @@ Add New User
 
    .. note:
 
-      The User Name must be alphanumeric and can include spaces, commas, underscores or hyphens. Maximum length is 64 characters.
+      The User Name must be alphanumeric and can include spaces, commas,
+      underscores or hyphens. Maximum length is 64 characters.
 
    .. figure:: /_figures/bare-metal-install-server/bare-metal-install-server-19.png
       :scale: 100%

--- a/source/guides/network/wifi.rst
+++ b/source/guides/network/wifi.rst
@@ -78,6 +78,8 @@ CLI (Command Line Interface)
 
    To avoid having the Wi-Fi password stored in bash history, consider using the TUI.
 
+.. _wifi-nm-tui:
+
 TUI (Text-based User Interface)
 ===============================
 


### PR DESCRIPTION
This PR updates the note about wireless connections in the live-server getting started guide. Particularly, it adds an achor reference to the recently published configure wifi guide and moves the note to a logical place for the needed order of operations. 