### PR TITLE
Update landing page

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/layout.html
+++ b/source/_themes/otc_tcs_sphinx_theme/layout.html
@@ -47,6 +47,10 @@
 
 <div id="trademarks">
   <p>*Other names and brands may be claimed as the property of others.</p>
+  <ul class="footer__menu_list">
+    <li class="footer__menu_list"><a href="https://www.intel.com/content/www/us/en/legal/trademarks.html">*Trademarks</a></li>
+    <li class="footer__menu_list"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></li>
+    <li class="footer__menu_list"><a href="https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html">Privacy Terms</a></li>
 </div>
 
 {% endblock %}

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -520,3 +520,20 @@ div.linenodiv:before { /*add extra new line to make sure code and line numbers a
 }
 
 /*End support for multi-column sections*/
+
+/*Start fix for changes made to definition lists in sphinx/rtd post version 2.0*/
+
+.rst-content dl:not(.docutils) dt {
+  border-top: none;
+  background: none;
+}
+
+/*end fix to definition lists*/
+
+ul.footer__menu_list {
+  display: inline-flex;
+}
+
+li.footer__menu_list {
+  margin-right: 30px;
+}

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -530,6 +530,7 @@ div.linenodiv:before { /*add extra new line to make sure code and line numbers a
 
 /*end fix to definition lists*/
 
+/*start formatting support for horizontal bullet list without bullets in footer*/
 ul.footer__menu_list {
   display: inline-flex;
 }
@@ -537,3 +538,4 @@ ul.footer__menu_list {
 li.footer__menu_list {
   margin-right: 30px;
 }
+/*end footer bullet list support*/

--- a/source/conf.py
+++ b/source/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 # General information about the project.
 #project = u'Clear Linux* project'
 project = u'Clear Linux* Project Docs'
-copyright = u'2019.'
+copyright = u'2020.'
 author = u'many'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/source/index.rst
+++ b/source/index.rst
@@ -53,23 +53,11 @@
 
    .. container:: column featurecard
 
-      .. toctree:: 
-         :caption: Documentation Contents
-         :maxdepth: 1
-
-         get-started/index
-         about
-         guides/index
-         tutorials/index
-         reference/index
-         FAQ/index
-         collaboration/collaboration
-
-      **Need some help?**
+      **Community**
 
       | `Ask the Clear Linux experts <https://clearlinux.org/community/mailing-list>`_
       | `Clear Linux Forum <https://community.clearlinux.org/>`_
-      | `IRC-based support <https://webchat.freenode.net/>`_
+      | `Freenode IRC: #clearlinux <https://webchat.freenode.net/>`_
 
 
 .. container:: video
@@ -77,3 +65,14 @@
    .. raw:: html
 
       <iframe width="100%" height="100%" src="https://www.youtube.com/embed/JFg-_5xihkE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="padding:10px; background-color: #fff;"></iframe>
+
+.. toctree:: 
+   :hidden:
+
+   get-started/index
+   about
+   guides/index
+   tutorials/index
+   reference/index
+   FAQ/index
+   collaboration/collaboration

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,61 +1,79 @@
 .. _clear-linux:
 
-|CL-PRJ|
+|CL-PRJ| Documentation
 #############################################
 
-Welcome to the |CL-ATTR| documentation pages, the source for |CL| documentation.
+.. container:: multicolumns
 
-Our documentation is divided into the following sections:
+   .. container:: column verticalcard
+
+      .. rst-class:: colh2
+
+      Highlights
+
+      :ref:`autospec`
+         **autospec** is a tool to assist in the automated creation and
+         maintenance of RPM packaging in Clear Linux OS. 
+
+      :ref:`dlrs`
+         This tutorial shows you how to run benchmarking workloads in Clear
+         Linux OS using TensorFlow\* or PyTorch\* with the Deep Learning
+         Reference Stack.
+
+      :ref:`docker`
+         Clear Linux OS supports multiple containerization platforms,
+         including a Docker solution.
+
+      :ref:`developer-workstation`      
+         Developer Workstation helps you find the Bundles you need to start
+         your Clear Linux OS development project.
+
+   .. container:: column verticalcard
+
+      .. rst-class:: colh2
+
+      Quicklinks
+
+      :ref:`get-started`
+         Get up and running fast with Clear Linux\* OS. Use these step-by-step
+         instructions to guide you through the installation of Clear Linux OS
+         from bare metal to live image.
+
+      :ref:`bare-metal-install-desktop`
+         These instructions guide you through the installation of Clear Linux
+         OS on bare metal using a bootable USB drive.
+
+      :ref:`architect-lifecycle`
+         This guide provides DevOps with a model to architect the life-cycle
+         of a Clear Linux OS derivative that integrates custom software and
+         content using distinct workflows.
+
+      :ref:`bundles`
+         Useful bundle commands for working with bundles on the Clear Linux OS.
+
+   .. container:: column featurecard
+
+      .. toctree:: 
+         :caption: Documentation Contents
+         :maxdepth: 1
+
+         get-started/index
+         about
+         guides/index
+         tutorials/index
+         reference/index
+         FAQ/index
+         collaboration/collaboration
+
+      **Need some help?**
+
+      | `Ask the Clear Linux experts <https://clearlinux.org/community/mailing-list>`_
+      | `Clear Linux Forum <https://community.clearlinux.org/>`_
+      | `IRC-based support <https://webchat.freenode.net/>`_
 
 
-:ref:`get-started`
+.. container:: video
 
-    If you are new to |CL|, get started quickly with step-by-step instructions
-    for installing |CL| on bare metal, in a virtual environment, or as a live
-    image on a USB stick.
+   .. raw:: html
 
-:ref:`about`
-
-    |CL| is different from other Linux distributions.
-
-    Updates, ease of use, and custom derivatives are a few of the differences
-    this section explains. Orient yourself to these differences and why they
-    matter to you.
-
-    .. raw:: html
-
-       <iframe width="560" height="315" src="https://www.youtube.com/embed/JFg-_5xihkE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="padding:10px; background-color: #fff;"></iframe>
-
-:ref:`guides`
-
-    Guides cover a range of topics from |CL| features and tooling, to system
-    maintenance, network, and stacks.
-
-:ref:`Use case tutorials <tutorials>`
-
-    Sample use cases, with step-by-step instructions, show how to set up
-    third-party tools and software with |CL|.
-
-:ref:`reference`
-
-    This section provides additional reference information on the |CL| project.
-
-:ref:`faq`
-
-    The FAQ section provides answers to commonly asked questions about |CL|.
-
-:ref:`collaboration`
-
-    This section describes how to contribute to |CL| documentation.
-
-.. toctree::
-    :maxdepth: 2
-    :hidden:
-
-    get-started/index
-    about
-    guides/index
-    tutorials/index
-    reference/index
-    FAQ/index
-    collaboration/collaboration
+      <iframe width="100%" height="100%" src="https://www.youtube.com/embed/JFg-_5xihkE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="padding:10px; background-color: #fff;"></iframe>


### PR DESCRIPTION
1. Updated landing page to emulate look and feel of docs page on clearlinux.org
2. Added Trademarks, Cookies, and Privacy Terms links to footer with some css formatting
3. Added some CSS to pre-emptively remove added formatting to definition list entries in sphinx/rtd theme in version 2 and above