### PR TITLE
Fix missing backslashes for Windows path in vmw-player

### DIFF
--- a/source/get-started/virtual-machine-install/vmw-player.rst
+++ b/source/get-started/virtual-machine-install/vmw-player.rst
@@ -296,7 +296,7 @@ in the **Install |CL| using ISO** tab.  Otherwise, follow the
             files under:
 
             * Linux distros :file:`/home/username/vmware`
-            * Windows :file:`C:\Users\username\Documents\Virtual Machines`
+            * Windows :file:`C:\\Users\\username\\Documents\\Virtual Machines`
 
       #. Start the ``VMware Workstation Player`` app.
 


### PR DESCRIPTION
Closes #1017

Signed-off-by: Bun K Tan <bun.k.tan@intel.com>