### PR TITLE
Fix typo: s/bundle <search term>/search <term>/

### DIFF
--- a/source/guides/clear/swupd.rst
+++ b/source/guides/clear/swupd.rst
@@ -318,7 +318,7 @@ swupd update <version number>
 swupd bundle-list [--all]
    Lists installed bundles.
 
-swupd bundle <search term>
+swupd search <term>
    Finds a bundle that contains your search term.
 
 swupd bundle-add <bundle name>


### PR DESCRIPTION
On my computer, `swupd search <term>` is the command which worked.