### PR TITLE
Note support for f2fs for clr-installer

### DIFF
--- a/source/get-started/bare-metal-install-desktop.rst
+++ b/source/get-started/bare-metal-install-desktop.rst
@@ -380,7 +380,7 @@ root partition
 
    * :guilabel:`New size:`                <varies>
    * :guilabel:`Partition name:`          CLR_ROOT
-   * :guilabel:`File system:`             ext[234] or XFS
+   * :guilabel:`File system:`             ext[234], XFS, or f2fs
    * :guilabel:`Label:`                   root
 
    .. figure:: /_figures/bare-metal-install-desktop/bare-metal-install-desktop-14.png
@@ -648,7 +648,7 @@ Create partitions per requirements in Table 1.
      -
      - 256MB
 
-   * - **ext[234] or XFS**
+   * - **ext[234], XFS, or f2fs**
      - root
      - /
      - *Size depends upon use case/desired bundles.*

--- a/source/get-started/bare-metal-install-server.rst
+++ b/source/get-started/bare-metal-install-server.rst
@@ -353,7 +353,7 @@ root partition
 #. Enter the hex code `8300` and press :kbd:`Enter`.
 
 #. In :guilabel:`Enter new partition name...`, type: CLR_ROOT.
-   The `/root` partition must be `ext[234]` or `XFS`.
+   The `/root` partition must be `ext[234]`, `XFS`,  or `f2fs`.
    If no filesystem exists, the installer will default to `VFAT(FAT32)`
    for `/boot`, and `ext4` for all others.
 
@@ -921,7 +921,7 @@ Create partitions per requirements in Table 1.
      -
      - 256MB
 
-   * - ``ext[234] or XFS``
+   * - ``ext[234], `XFS`, or f2fs``
      - root
      - /
      - *Size depends upon use case/desired bundles.*


### PR DESCRIPTION
Support for f2fs file system type was enabled in the clr-installer release 2.4.1.
https://github.com/clearlinux/clr-installer/pull/654
