### PR TITLE
Adds ticks, File System descriptors, Default part schema, bare-metal-install-desktop

### DIFF
--- a/source/get-started/bare-metal-install-desktop.rst
+++ b/source/get-started/bare-metal-install-desktop.rst
@@ -638,17 +638,17 @@ Create partitions per requirements in Table 1.
      - Mount Point
      - Default size
 
-   * - **VFAT (FAT32)**
+   * - ``VFAT (FAT32)``
      - boot
      - /boot
      - 150MB
 
-   * - **linux-swap**
+   * - ``linux-swap``
      - swap
      -
      - 256MB
 
-   * - **ext[234], XFS, or f2fs**
+   * - ``ext[234], XFS, or f2fs``
      - root
      - /
      - *Size depends upon use case/desired bundles.*


### PR DESCRIPTION
- TCS follow-on to GH-1056
- Match exatcly syntax in bare-metal-install-desktop
- Improve UI legibility in HTML

Signed-off-by: Michael Vincerra <michael.vincerra@intel.com>