### PR TITLE
Added another step

### DIFF
--- a/source/tutorials/nvidia.rst
+++ b/source/tutorials/nvidia.rst
@@ -286,6 +286,11 @@ Install the NVIDIA drivers
 
       ln -sv /opt/nvidia/share/applications/nvidia-settings.desktop $HOME/.local/share
 
+#. Optional: Link NVIDIA application profiles to where they are searched for
+
+   .. code-block:: bash
+
+      ln -s /etc/nvidia /usr/share
 
 Updating
 ********


### PR DESCRIPTION
run ❯ nvidia-settings after installing the app profiles to /etc/nvidia you'll get this:

(nvidia-settings:16608): GLib-GObject-CRITICAL **: 01:26:53.561: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

ERROR: nvidia-settings could not find the registry key file. This file should have been installed along with this driver at
       either /usr/share/nvidia/nvidia-application-profiles-440.59-key-documentation or
       /usr/share/nvidia/nvidia-application-profiles-key-documentation. The application profiles will continue to work, but
       values cannot be prepopulated or validated, and will not be listed in the help text. Please see the README for possible
       values and descriptions.

which is a problem https://devtalk.nvidia.com/default/topic/1072456/linux/all-gui-apps-low-fps-when-mouse-is-inactive-x-org-1-20-7-rtx2080ti/

I'm not sure why the author chose to install them in /etc/nvidia they aren't looked for there.  I'm not sure how much buggery it would be to keep /usr/share sacred but this one link is the difference between gui apps running like dirt.