### PR TITLE
Added fix for swupd bundle-add Error

### DIFF
--- a/source/guides/stacks/dlrs.rst
+++ b/source/guides/stacks/dlrs.rst
@@ -109,7 +109,7 @@ instructions in :ref:`kubernetes`.
 
 .. warning::
 
-   Note that although the DLRS images and dockerfiles may be modified for your needs, there are some modifications that may cause unexpected or undesirable results.  For example, using the Clear Linux :command:`swupd bundle-add` command to add packages to a Clear Linux based container may overwrite the DLRS core components.  Please use care when modifying the contents of the containers.
+   Note that although the DLRS images and dockerfiles may be modified for your needs, there are some modifications that may cause unexpected or undesirable results.  For example, using the Clear Linux :command:`swupd bundle-add` command to add packages to a Clear Linux based container may overwrite the DLRS core components.  Please use care when modifying the contents of the containers. If recaving Errors using the Clear Linux :command:`swupd bundle-add` command try running the Clear Linux :command:`swupd clean` command first.
 
 
 Kubectl


### PR DESCRIPTION
Signed-off-by: Anthony Pray anthony.s.pray@intel.com
When using the docker image you may see error
"Failed to install x of x"
ruining  "swupd clean" will fix the problems.