### PR TITLE
Fixed broken links

### DIFF
--- a/source/guides/clear/mixer.rst
+++ b/source/guides/clear/mixer.rst
@@ -1124,7 +1124,7 @@ the nginx web server is used.
 
       sudo systemctl enable nginx --now
 
-#. Verify the web server is running at http://<IP-address-of-web-server>.
+#. Verify the web server is running at \http://<IP-address-of-web-server>.
    If there's no mix content yet, the expected response from nginx will be 
    a ``404 Not Found``.
 

--- a/source/guides/maintenance/developer-workstation.rst
+++ b/source/guides/maintenance/developer-workstation.rst
@@ -55,7 +55,7 @@ tools you need to start. Consider these profiles as a starting point.
            - `machine-learning-web-ui <https://clearlinux.org/software/bundle/machine-learning-web-ui/>`_
 
          * - Machine learning Docker container.
-           - `machine-learning <https://clearlinux.org/software/docker/machine-learning/>`_
+           - `machine-learning <https://clearlinux.org/software/docker/machine-learning-ui/>`_
 
          * - Pre-built Python libraries for Data Science.
            - `python-extras <https://clearlinux.org/software/bundle/python-extras>`_
@@ -183,14 +183,14 @@ tools you need to start. Consider these profiles as a starting point.
          * - Run a secure shell (SSH) server for access from remote machines.
            - `openssh-server <https://clearlinux.org/software/bundle/openssh-server/>`_
 
-         * - Run a HTTP web server.
-           - `web-server-basic <https://clearlinux.org/software/bundle/web-server-basic>`_
+         * - Run an HTTP server.
+           - `nginx <https://clearlinux.org/software/bundle/nginx>`_
 
          * - Run an application server via HTTP.
            - `application-server <https://clearlinux.org/software/bundle/application-server/>`_
 
-         * - Run an SQL database.
-           - `database-basic <https://clearlinux.org/software/bundle/database-basic>`_
+         * - Run a SQLite database.
+           - `sqlite <https://clearlinux.org/software/bundle/sqlite>`_
 
          * - Bundle to automatically launch the GUI upon boot.
            - `desktop-autostart <https://clearlinux.org/software/bundle/desktop-autostart/>`_


### PR DESCRIPTION
Added escape character so they aren't turned into links:
guides/clear/mixer.rst:1127:
   [broken] http:/
guides/clear/swupd-3rd-party.rst:61:
   [broken] http:/

Pointed to containers and bundles that still exist:
guides/maintenance/developer-workstation.rst:58:
   [broken] https://clearlinux.org/software/docker/machine-learning/
guides/maintenance/developer-workstation.rst:187:
   [broken] https://clearlinux.org/software/bundle/web-server-basic
guides/maintenance/developer-workstation.rst:193:
   [broken] https://clearlinux.org/software/bundle/database-basic

Unable to fix - this document doesn't appear to exist. Recommend removing reference.
guides/stacks/dbrs.rst:41:
   [broken] https://clearlinux.org/news-blogs/database-reference-stack-dbrs-v2-now-available

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>