### PR TITLE
Add one line of bash to apply flannel plugin.

### DIFF
--- a/source/tutorials/kubernetes.rst
+++ b/source/tutorials/kubernetes.rst
@@ -452,8 +452,15 @@ Kubernetes container runtime:
    .. code:: bash
 
       sudo kubeadm init \
-      --pod-network-cidr 10.244.0.0/16 
-
+      --pod-network-cidr 10.244.0.0/16
+   .. important::
+   
+      We need to install the pod network before the cluster can come up. The following will install the latest yaml file that flannel provides. 
+   
+   .. code:: bash
+   
+      kubectl apply -f https://github.com/coreos/flannel/raw/master/Documentation/kube-flannel.yml
+   
 
 #. Once the cluster initialization is complete, continue reading about how to
    `Use your cluster`_.


### PR DESCRIPTION
A container network interface is needed to run the "manually" set up cluster without removing references to $KUBELET_NETWORK_ARGS and just using the whatever the underlying container runtime gives you. 
In most cases this is not the desired outcome.
 - Flannel is the simplest implementation
 - It works well with the instructions already given
 - This way a user can leave the "Set up Kubernetes manually" tutorial with a running cluster under their belt