### PR TITLE
Add include in ZFS tutorial to reference kernel-module-dkms

### DIFF
--- a/source/guides/kernel/kernel-modules-dkms.rst
+++ b/source/guides/kernel/kernel-modules-dkms.rst
@@ -64,8 +64,10 @@ The :command:`kernel-native-dkms` bundle also:
    kernel. This is especially important for systems where a successful boot
    relies on a kernel module.
 
+.. _kernel-modules-dkms-install-begin-alt:
+
 Install the :command:`kernel-native-dkms` or :command:`kernel-lts-dkms`
-bundle:
+bundle.
 
 #. Determine which kernel variant is running on |CL|. Only the *native*
    and *lts* kernels are enabled to build and load out-of-tree kernel modules
@@ -93,7 +95,8 @@ bundle:
       sudo swupd bundle-add kernel-lts-dkms
 
 
-#. Update the |CL| bootloader and reboot.
+#. Update the |CL| bootloader and reboot, and 
+   ensure that you can start the new kernel.
 
    .. code-block:: bash
 

--- a/source/tutorials/zfs.rst
+++ b/source/tutorials/zfs.rst
@@ -32,29 +32,9 @@ Prerequisites
 Install the DKMS kernel
 =======================
 
-If you do not currently use a DKMS kernel, install it by using one of the options below.
-
-#.  Check whether you have an LTS or native kernel:
-
-    .. code-block:: bash
-  
-       uname -r
-
-    a. If 'native' appears in the kernel name, then install a native
-       kernel with DKMS support:
-
-       .. code-block:: bash
-
-          sudo swupd bundle-add kernel-native-dkms
-
-    #. If 'lts' appears in the kernel name, then install the latest LTS
-       kernel with DKMS support:
-
-       .. code-block:: bash
-
-          sudo swupd bundle-add kernel-lts-dkms
-
-#. Reboot and make sure you can start the new kernel.
+.. include:: ../guides/kernel/kernel-modules-dkms.rst
+   :start-after: kernel-modules-dkms-install-begin-alt:
+   :end-before: kernel-modules-dkms-install-end:
 
 Bundles
 =======


### PR DESCRIPTION
- Closes #1192 
- Docs should follow DRY and be modular. Use include directive where possible and feasible