### PR TITLE
add dep for create_stack.sh kubernetes script

### DIFF
--- a/source/tutorials/kubernetes.rst
+++ b/source/tutorials/kubernetes.rst
@@ -115,6 +115,14 @@ running quickly.
 
       sudo systemctl stop docker
       sudo systemctl stop containerd
+      
+
+#. Install git as it's a dependency of the :file:`create_stack.sh`.
+
+   .. code-block:: bash
+
+      sudo swupd bundle-add git
+
 
 #. Run the :file:`create_stack.sh` script to initialize the Kubernetes node
    and setup a container network plugin.


### PR DESCRIPTION
The create_stack.sh script requires git to complete fully. Perhaps this should be added to the setup_system.sh script, but until it does, this change allows the steps to complete without error.