### PR TITLE
Update lamp-server.rst

### DIFF
--- a/source/tutorials/lamp-server.rst
+++ b/source/tutorials/lamp-server.rst
@@ -246,7 +246,7 @@ and is available in the database-basic |CL| bundle.
 
    .. code-block:: bash
 
-      sudo swupd bundle-add database-basic
+      sudo swupd bundle-add mariadb
 
 #. To start MariaDB after it is installed and set it to start automatically on
    boot, enter the following commands:


### PR DESCRIPTION
sudo swupd bundle-add database-basic

needs to be replaced by:

sudo swupd bundle-add mariadb

As database-basic bundle is invalid. 