### PR TITLE
Fix #use-your-cluster link on kubernetes docs

### DIFF
--- a/source/tutorials/kubernetes.rst
+++ b/source/tutorials/kubernetes.rst
@@ -132,7 +132,7 @@ running quickly.
       sudo /usr/share/clr-k8s-examples/create_stack.sh minimal
 
 #. Follow the output on the screen and continue onto the section on `using
-   your cluster <Use your cluster>`_.
+   your cluster <#use-your-cluster>`_.
 
 
 Uninstalling


### PR DESCRIPTION
You can see it currently goes to `https://docs.01.org/clearlinux/latest/tutorials/Useyourcluster`. It needs `<#use-your-cluster>` for the link to generate correctly.