### PR TITLE
Fix wrong package name in lamp-server tutorial.

### DIFF
--- a/source/tutorials/lamp-server.rst
+++ b/source/tutorials/lamp-server.rst
@@ -246,7 +246,7 @@ and is available in the database-basic |CL| bundle.
 
    .. code-block:: bash
 
-      sudo swupd bundle-add database-basic
+      sudo swupd bundle-add mariadb
 
 #. To start MariaDB after it is installed and set it to start automatically on
    boot, enter the following commands:


### PR DESCRIPTION
database-basic is no longer used, there is a mariadb package now.

Closes #1226 
