### PR TITLE
Screen Media Background Color

### DIFF
--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -3,7 +3,7 @@
 /* make the page width fill the window */
 .wy-nav-content {
    max-width: 1100px;
-   background: linear-gradient(white 58px, #f3f3f2 58px 100%);
+   background: linear-gradient(white 58px, #f5f5f2 58px 100%);
    padding-top: 10px;
    padding-right: 20px;
    padding-left: 20px;

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -3,7 +3,7 @@
 /* make the page width fill the window */
 .wy-nav-content {
    max-width: 1100px;
-   background: linear-gradient(white 58px, #f2f4f5 58px 100%);
+   background: linear-gradient(white 58px, #f5f4f2 58px 100%);
    padding-top: 10px;
    padding-right: 20px;
    padding-left: 20px;

--- a/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
+++ b/source/_themes/otc_tcs_sphinx_theme/static/tcs_theme.css
@@ -3,7 +3,7 @@
 /* make the page width fill the window */
 .wy-nav-content {
    max-width: 1100px;
-   background: linear-gradient(white 58px, #f5f4f2 58px 100%);
+   background: linear-gradient(white 58px, #f3f3f2 58px 100%);
    padding-top: 10px;
    padding-right: 20px;
    padding-left: 20px;


### PR DESCRIPTION
you are displaying black text on top of a blue background for documentation.
![caption](https://live.staticflickr.com/65535/52095039742_7a8d840558_w.jpg)
this is f5f4f2 instead of f2f4f5
screens are notorious for blue glare and the blue coloring would only be exacerbating it
![caption](https://live.staticflickr.com/65535/52096133111_4de32037f2_n.jpg)
this is f3f3f2, I think more appropriate than the first alternate I screenshot
![caption](https://live.staticflickr.com/65535/52096415389_12b7ebc8c0_z.jpg)
f5f5f2 I think the most clear
![caption](https://live.staticflickr.com/65535/52096682005_3a48fd8a0b.jpg)
the before and after