### PR TITLE
Revise canonical_url to newly assigned one in conf.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -142,7 +142,8 @@ version = current_version = "latest"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  'canonical_url': 'docs.01.org/clearlinux/',
+#   'canonical_url': 'docs.01.org/clearlinux/', # remove old url - mv
+  'canonical_url': 'clearlinux.github.io/clear-linux-documentation/',
   'style_nav_header_background': '#007ab2',
   'navigation_depth': 4,
   'display_version': False,


### PR DESCRIPTION
Sometime during last two months, team assiged a new URL, but did not change `canonical_url` in conf.py. This corrects that error.

Signed-off-by: michael vincerra <michael.vincerra@intel.com>