### PR TITLE
Fix broken domain name in crosslink to cpu-performance.

### DIFF
--- a/source/guides/clear/performance.rst
+++ b/source/guides/clear/performance.rst
@@ -214,7 +214,7 @@ CPU performance governor
 maximum clock frequency. In other words, P-state P0. The idea behind prioritizing
 maximum CPU performance is that the faster a program finishes execution, the
 faster the CPU can return to a low energy idle state. See the `CPU Power and
-Performance documentation <https://docs.01.org/clearlinux/latest/guides/maintenance/cpu-performance.html>`_
+Performance documentation <https://www.clearlinux.org/clear-linux-documentation/guides/maintenance/cpu-performance.html>`_
 for further details.
 
 Restructured boot sequence


### PR DESCRIPTION
it appears the docs.01.org/clearlinux domain name is yours and redirects to clearlinux.org, but the path being used gives a 404 - this proposes the direct link.  edit the PR as you see fit per your doc link management desires.