### PR TITLE
Fix KVM instructions for zsh users

### DIFF
--- a/source/get-started/virtual-machine-install/kvm.rst
+++ b/source/get-started/virtual-machine-install/kvm.rst
@@ -41,7 +41,7 @@ Download and launch the virtual machine image
 
    .. code-block:: bash
 
-      curl -o clear.img.xz https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images.json | grep -o clear-'[0-9]'*-kvm.img.xz | head -1)
+      curl -o clear.img.xz https://cdn.download.clearlinux.org/image/$(curl https://cdn.download.clearlinux.org/image/latest-images.json | grep -o 'clear-[0-9]*-kvm.img.xz' | head -1)
 
 #. Uncompress the downloaded image:
 


### PR DESCRIPTION
The instructions for downloading the KVM image fail under zsh because it tries to expand the `*` that is outside of the quotes.

Quoting the entire filename makes the command work on both zsh and bash.